### PR TITLE
Adding the converts for the IElement migration

### DIFF
--- a/BHoMUpgrader30/BHoMUpgrader30.csproj
+++ b/BHoMUpgrader30/BHoMUpgrader30.csproj
@@ -63,10 +63,6 @@
     <Reference Include="Data_oM">
       <HintPath>..\..\BHoM\Build\Data_oM.dll</HintPath>
     </Reference>
-    <Reference Include="Dimensional_oM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM\Build\Dimensional_oM.dll</HintPath>
-    </Reference>
     <Reference Include="Geometry_oM">
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
     </Reference>

--- a/BHoMUpgrader30/BHoMUpgrader30.csproj
+++ b/BHoMUpgrader30/BHoMUpgrader30.csproj
@@ -63,6 +63,10 @@
     <Reference Include="Data_oM">
       <HintPath>..\..\BHoM\Build\Data_oM.dll</HintPath>
     </Reference>
+    <Reference Include="Dimensional_oM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\Dimensional_oM.dll</HintPath>
+    </Reference>
     <Reference Include="Geometry_oM">
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
     </Reference>

--- a/BHoMUpgrader31/BHoMUpgrader31.csproj
+++ b/BHoMUpgrader31/BHoMUpgrader31.csproj
@@ -33,33 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Architecture_oM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\BHoM\Build\Architecture_oM.dll</HintPath>
-    </Reference>
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
-    </Reference>
-    <Reference Include="Common_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Common_Engine.dll</HintPath>
-    </Reference>
-    <Reference Include="Dimensional_oM">
-      <HintPath>..\..\BHoM\Build\Dimensional_oM.dll</HintPath>
-    </Reference>
-    <Reference Include="Environment_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Environment_Engine.dll</HintPath>
-    </Reference>
-    <Reference Include="Environment_oM">
-      <HintPath>..\..\BHoM\Build\Environment_oM.dll</HintPath>
-    </Reference>
-    <Reference Include="Geometry_oM">
-      <HintPath>..\..\..\Users\kthorsager\OneDrive - BuroHappold\Documents\GitHub\BHoM\Geometry_oM\obj\Debug\Geometry_oM.dll</HintPath>
-    </Reference>
-    <Reference Include="Structure_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Structure_Engine.dll</HintPath>
-    </Reference>
-    <Reference Include="Structure_oM">
-      <HintPath>..\..\..\Users\kthorsager\OneDrive - BuroHappold\Documents\GitHub\BHoM\Structure_oM\obj\Debug\Structure_oM.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BHoMUpgrader31/BHoMUpgrader31.csproj
+++ b/BHoMUpgrader31/BHoMUpgrader31.csproj
@@ -55,9 +55,6 @@
     <Reference Include="Geometry_oM">
       <HintPath>..\..\..\Users\kthorsager\OneDrive - BuroHappold\Documents\GitHub\BHoM\Geometry_oM\obj\Debug\Geometry_oM.dll</HintPath>
     </Reference>
-    <Reference Include="ModelLaundry_Engine">
-      <HintPath>..\..\ModelLaundry_Toolkit\Build\ModelLaundry_Engine.dll</HintPath>
-    </Reference>
     <Reference Include="Structure_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Structure_Engine.dll</HintPath>
     </Reference>

--- a/BHoMUpgrader31/BHoMUpgrader31.csproj
+++ b/BHoMUpgrader31/BHoMUpgrader31.csproj
@@ -33,8 +33,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Architecture_oM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\Architecture_oM.dll</HintPath>
+    </Reference>
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
+    </Reference>
+    <Reference Include="Common_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Common_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Dimensional_oM">
+      <HintPath>..\..\BHoM\Build\Dimensional_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="Environment_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Environment_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Environment_oM">
+      <HintPath>..\..\BHoM\Build\Environment_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="Geometry_oM">
+      <HintPath>..\..\..\Users\kthorsager\OneDrive - BuroHappold\Documents\GitHub\BHoM\Geometry_oM\obj\Debug\Geometry_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="ModelLaundry_Engine">
+      <HintPath>..\..\ModelLaundry_Toolkit\Build\ModelLaundry_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Structure_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Structure_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Structure_oM">
+      <HintPath>..\..\..\Users\kthorsager\OneDrive - BuroHappold\Documents\GitHub\BHoM\Structure_oM\obj\Debug\Structure_oM.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BHoMUpgrader31/TypeConverter.cs
+++ b/BHoMUpgrader31/TypeConverter.cs
@@ -36,14 +36,20 @@ namespace BH.Upgrader.v31
 
         public Dictionary<string, string> ToNewType { get; set; } = new Dictionary<string, string>
         {
-            
+            { "BH.oM.Geometry.IElement", "BH.oM.Dimensional.IElement" },
+            { "BH.oM.Geometry.IElement0D", "BH.oM.Dimensional.IElement0D" },
+            { "BH.oM.Geometry.IElement1D", "BH.oM.Dimensional.IElement1D" },
+            { "BH.oM.Geometry.IElement2D", "BH.oM.Dimensional.IElement2D" }
         };
 
         /***************************************************/
 
         public Dictionary<string, string> ToOldType { get; set; } = new Dictionary<string, string>
         {
-            
+            { "BH.oM.Dimensional.IElement", "BH.oM.Geometry.IElement" },
+            { "BH.oM.Dimensional.IElement0D", "BH.oM.Geometry.IElement0D" },
+            { "BH.oM.Dimensional.IElement1D", "BH.oM.Geometry.IElement1D" },
+            { "BH.oM.Dimensional.IElement2D", "BH.oM.Geometry.IElement2D" }
         };
 
         /***************************************************/


### PR DESCRIPTION
### NOTE: Depends on
https://github.com/BHoM/BHoM/pull/704

### Necessary for testing
https://github.com/BHoM/BHoM_Engine/pull/1484
since this is what it upgrades to

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Adds the conversion methods for the move of IElements.

Both type conversion and method conversion.

### Test files

### Changelog

### Additional comments