### PR TITLE
Type upgrader for IBHoMFragment to IFragment

### DIFF
--- a/BHoMUpgrader31/TypeConverter.cs
+++ b/BHoMUpgrader31/TypeConverter.cs
@@ -40,7 +40,8 @@ namespace BH.Upgrader.v31
             { "BH.oM.Geometry.IElement", "BH.oM.Dimensional.IElement" },
             { "BH.oM.Geometry.IElement0D", "BH.oM.Dimensional.IElement0D" },
             { "BH.oM.Geometry.IElement1D", "BH.oM.Dimensional.IElement1D" },
-            { "BH.oM.Geometry.IElement2D", "BH.oM.Dimensional.IElement2D" }
+            { "BH.oM.Geometry.IElement2D", "BH.oM.Dimensional.IElement2D" },
+            { "BH.oM.Base.IBHoMFragment", "BH.oM.Base.IFragment" }
         };
 
         /***************************************************/
@@ -51,7 +52,8 @@ namespace BH.Upgrader.v31
             { "BH.oM.Dimensional.IElement", "BH.oM.Geometry.IElement" },
             { "BH.oM.Dimensional.IElement0D", "BH.oM.Geometry.IElement0D" },
             { "BH.oM.Dimensional.IElement1D", "BH.oM.Geometry.IElement1D" },
-            { "BH.oM.Dimensional.IElement2D", "BH.oM.Geometry.IElement2D" }
+            { "BH.oM.Dimensional.IElement2D", "BH.oM.Geometry.IElement2D" },
+            { "BH.oM.Base.IFragment", "BH.oM.Base.IBHoMFragment" }
         };
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

Done to support https://github.com/BHoM/BHoM/pull/711
From my understanding though, this can be merged before the BHoM has been merged, as types are referenced by strings, and this will only get called when something goes wrong with deserialisation, hence, will only get called for old methods once the oM branch is merged. So, as long as we are sure on the change in BHoM (which I think we are) we can merge this PR straight away.

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #30 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->