### PR TITLE
Geometry_Engine: remove the ClipPolylines method

### DIFF
--- a/BHoMUpgrader31/BHoMUpgrader31.csproj
+++ b/BHoMUpgrader31/BHoMUpgrader31.csproj
@@ -36,6 +36,12 @@
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
     </Reference>
+    <Reference Include="Geometry_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Geometry_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Geometry_oM">
+      <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/BHoMUpgrader31/MethodConverter.cs
+++ b/BHoMUpgrader31/MethodConverter.cs
@@ -37,7 +37,10 @@ namespace BH.Upgrader.v31
 
         public Dictionary<string, MethodBase> ToNewMethod { get; set; } = new Dictionary<string, MethodBase>
         {
-            
+            {
+                "BH.Engine.Geometry.Compute.ClipPolylines(BH.oM.Geometry.Polyline, BH.oM.Geometry.Polyline)",
+                typeof(BH.Engine.Geometry.Compute).GetMethod("BooleanIntersection", new Type[] { typeof(BH.oM.Geometry.Polyline), typeof(BH.oM.Geometry.Polyline), typeof(double) })
+            },
         };
 
         /***************************************************/

--- a/Versioning_Toolkit.sln
+++ b/Versioning_Toolkit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.757
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BHoMUpgrader30", "BHoMUpgrader30\BHoMUpgrader30.csproj", "{10D377C5-E17D-4135-A9AA-EB106833A94E}"
 EndProject


### PR DESCRIPTION
Refers to https://github.com/BHoM/BHoM_Engine/pull/1551
ClipPolylines is removed from Geometry_Engine and Version controlled via the MethodConverter. BooleanIntersection is the replacement method.