### PR TITLE
Type Converter for ETABS PR281

### DIFF
--- a/BHoMUpgrader31/TypeConverter.cs
+++ b/BHoMUpgrader31/TypeConverter.cs
@@ -41,7 +41,8 @@ namespace BH.Upgrader.v31
             { "BH.oM.Geometry.IElement0D", "BH.oM.Dimensional.IElement0D" },
             { "BH.oM.Geometry.IElement1D", "BH.oM.Dimensional.IElement1D" },
             { "BH.oM.Geometry.IElement2D", "BH.oM.Dimensional.IElement2D" },
-            { "BH.oM.Base.IBHoMFragment", "BH.oM.Base.IFragment" }
+            { "BH.oM.Base.IBHoMFragment", "BH.oM.Base.IFragment" },
+            { "BH.oM.Adapters.ETABS.EtabsConfig", "BH.oM.Adapters.ETABS.EtabsSettings" }
         };
 
         /***************************************************/
@@ -53,7 +54,8 @@ namespace BH.Upgrader.v31
             { "BH.oM.Dimensional.IElement0D", "BH.oM.Geometry.IElement0D" },
             { "BH.oM.Dimensional.IElement1D", "BH.oM.Geometry.IElement1D" },
             { "BH.oM.Dimensional.IElement2D", "BH.oM.Geometry.IElement2D" },
-            { "BH.oM.Base.IFragment", "BH.oM.Base.IBHoMFragment" }
+            { "BH.oM.Base.IFragment", "BH.oM.Base.IBHoMFragment" },
+            { "BH.oM.Adapters.ETABS.EtabsSettings", "BH.oM.Adapters.ETABS.EtabsConfig" }
         };
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
Closes #
The ETABS toolkit changes its definition of EtabsConfig to EtabsSettings which we want to version.
This PR adds a type converter which solves that.
Relevant PR: https://github.com/BHoM/ETABS_Toolkit/pull/281

A note is due to the input param name change on the adapter, the wire connectivity is lost
and this will not update the EtabsConfig components, only the ETABSAdapter
### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/Ee2kdsVhG_xAv3HBDL3RvYIBwjjyI0XoaPWHyOy2SXjLLg?e=NIVO2H

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->