### PR TITLE
Removing any non-type part from the type string

### DIFF
--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -304,6 +304,9 @@ namespace BH.Upgrader.Base
 
         private static string GetTypeFromDic(Dictionary<string, string> dic, string type)
         {
+            if (type.Contains(","))
+                type = type.Split(',').First();
+
             if (dic.ContainsKey(type))
                 return dic[type];
             else


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #39 

<!-- Add short description of what has been fixed -->
Only get the Type part from the Type string by removing any part after the first ','

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->