### PR TITLE
Method Converts for the Common to Spatial migration

### DIFF
--- a/BHoMUpgrader31/BHoMUpgrader31.csproj
+++ b/BHoMUpgrader31/BHoMUpgrader31.csproj
@@ -36,10 +36,9 @@
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
     </Reference>
-    <Reference Include="Dimensional_oM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Dimensional_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Dimensional_oM.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Geometry_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Geometry_Engine.dll</HintPath>
@@ -49,7 +48,6 @@
     </Reference>
     <Reference Include="Spatial_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Spatial_Engine.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BHoMUpgrader31/BHoMUpgrader31.csproj
+++ b/BHoMUpgrader31/BHoMUpgrader31.csproj
@@ -36,11 +36,20 @@
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
     </Reference>
+    <Reference Include="Dimensional_oM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\Dimensional_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Geometry_Engine">
       <HintPath>..\..\BHoM_Engine\Build\Geometry_Engine.dll</HintPath>
     </Reference>
     <Reference Include="Geometry_oM">
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="Spatial_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Spatial_Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/BHoMUpgrader31/MethodConverter.cs
+++ b/BHoMUpgrader31/MethodConverter.cs
@@ -41,6 +41,320 @@ namespace BH.Upgrader.v31
                 "BH.Engine.Geometry.Compute.ClipPolylines(BH.oM.Geometry.Polyline, BH.oM.Geometry.Polyline)",
                 typeof(BH.Engine.Geometry.Compute).GetMethod("BooleanIntersection", new Type[] { typeof(BH.oM.Geometry.Polyline), typeof(BH.oM.Geometry.Polyline), typeof(double) })
             },
+            {
+            "BH.Engine.Common.Compute.DistributeOutlines(System.Collections.Generic.List<System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>>, System.Boolean, System.Double)",
+            typeof(BH.Engine.Spatial.Compute).GetMethod("DistributeOutlines", new Type[] {typeof(System.Collections.Generic.List<System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>>), typeof(System.Boolean), typeof(System.Double)})
+            },
+            {
+            "BH.Engine.Common.Modify.Translate(BH.oM.Dimensional.IElement2D, BH.oM.Geometry.Vector)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("Translate", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(BH.oM.Geometry.Vector)})
+            },
+            {
+            "BH.Engine.Common.Modify.Translate(BH.oM.Dimensional.IElement1D, BH.oM.Geometry.Vector)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("Translate", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(BH.oM.Geometry.Vector)})
+            },
+            {
+            "BH.Engine.Common.Modify.Translate(BH.oM.Dimensional.IElement0D, BH.oM.Geometry.Vector)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("Translate", new Type[] {typeof(BH.oM.Dimensional.IElement0D), typeof(BH.oM.Geometry.Vector)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetElements0D(BH.oM.Dimensional.IElement1D, System.Collections.Generic.List<BH.oM.Dimensional.IElement0D>)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetElements0D", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement0D>)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetGeometry(BH.oM.Dimensional.IElement0D, BH.oM.Geometry.Point)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetGeometry", new Type[] {typeof(BH.oM.Dimensional.IElement0D), typeof(BH.oM.Geometry.Point)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetGeometry(BH.oM.Dimensional.IElement1D, BH.oM.Geometry.ICurve)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetGeometry", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(BH.oM.Geometry.ICurve)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetInternalElements2D(BH.oM.Dimensional.IElement2D, System.Collections.Generic.List<BH.oM.Dimensional.IElement2D>)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetInternalElements2D", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement2D>)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetOutlineElements1D(BH.oM.Dimensional.IElement2D, System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetOutlineElements1D", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)})
+            },
+            {
+            "BH.Engine.Common.Query.Area(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Area", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.Bounds(BH.oM.Dimensional.IElement0D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Bounds", new Type[] {typeof(BH.oM.Dimensional.IElement0D)})
+            },
+            {
+            "BH.Engine.Common.Query.Bounds(BH.oM.Dimensional.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Bounds", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.Bounds(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Bounds", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IBounds(BH.oM.Dimensional.IElement)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IBounds", new Type[] {typeof(BH.oM.Dimensional.IElement)})
+            },
+            {
+            "BH.Engine.Common.Query.IBounds(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IBounds", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
+            },
+            {
+            "BH.Engine.Common.Query.Centroid(BH.oM.Dimensional.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Centroid", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.Centroid(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Centroid", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.ControlPoints(BH.oM.Dimensional.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ControlPoints", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.ControlPoints(BH.oM.Dimensional.IElement2D, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ControlPoints", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.ElementCurves(BH.oM.Dimensional.IElement1D, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementCurves", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.ElementCurves(BH.oM.Dimensional.IElement2D, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementCurves", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.IElementCurves(BH.oM.Dimensional.IElement, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElementCurves", new Type[] {typeof(BH.oM.Dimensional.IElement), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.IElementCurves(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElementCurves", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.ElementVertices(BH.oM.Dimensional.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementVertices", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.ElementVertices(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementVertices", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IElementVertices(BH.oM.Dimensional.IElement)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElementVertices", new Type[] {typeof(BH.oM.Dimensional.IElement)})
+            },
+            {
+            "BH.Engine.Common.Query.IElementVertices(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElementVertices", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
+            },
+            {
+            "BH.Engine.Common.Query.IElements0D(BH.oM.Dimensional.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElements0D", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.IGeometry(BH.oM.Dimensional.IElement0D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IGeometry", new Type[] {typeof(BH.oM.Dimensional.IElement0D)})
+            },
+            {
+            "BH.Engine.Common.Query.IGeometry(BH.oM.Dimensional.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IGeometry", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.IInternalElements2D(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IInternalElements2D", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IInternalOutlineCurves(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IInternalOutlineCurves", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IsSelfIntersecting(BH.oM.Dimensional.IElement1D, System.Double)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IsSelfIntersecting", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(System.Double)})
+            },
+            {
+            "BH.Engine.Common.Query.IsSelfIntersecting(BH.oM.Dimensional.IElement2D, System.Double)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IsSelfIntersecting", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Double)})
+            },
+            {
+            "BH.Engine.Common.Query.Length(BH.oM.Dimensional.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Length", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.Normal(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Normal", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IOutlineElements1D(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineElements1D", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IOutlineCurve(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineCurve", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IOutlineCurve(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineCurve", new Type[] {typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)})
+            },
+
+
+            {
+            "BH.Engine.Common.Compute.DistributeOutlines(System.Collections.Generic.List<System.Collections.Generic.List<BH.oM.Geometry.IElement1D>>, System.Boolean, System.Double)",
+            typeof(BH.Engine.Spatial.Compute).GetMethod("DistributeOutlines", new Type[] {typeof(System.Collections.Generic.List<System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>>), typeof(System.Boolean), typeof(System.Double)})
+            },
+            {
+            "BH.Engine.Common.Modify.Translate(BH.oM.Geometry.IElement2D, BH.oM.Geometry.Vector)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("Translate", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(BH.oM.Geometry.Vector)})
+            },
+            {
+            "BH.Engine.Common.Modify.Translate(BH.oM.Geometry.IElement1D, BH.oM.Geometry.Vector)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("Translate", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(BH.oM.Geometry.Vector)})
+            },
+            {
+            "BH.Engine.Common.Modify.Translate(BH.oM.Geometry.IElement0D, BH.oM.Geometry.Vector)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("Translate", new Type[] {typeof(BH.oM.Dimensional.IElement0D), typeof(BH.oM.Geometry.Vector)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetElements0D(BH.oM.Geometry.IElement1D, System.Collections.Generic.List<BH.oM.Geometry.IElement0D>)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetElements0D", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement0D>)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetGeometry(BH.oM.Geometry.IElement0D, BH.oM.Geometry.Point)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetGeometry", new Type[] {typeof(BH.oM.Dimensional.IElement0D), typeof(BH.oM.Geometry.Point)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetGeometry(BH.oM.Geometry.IElement1D, BH.oM.Geometry.ICurve)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetGeometry", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(BH.oM.Geometry.ICurve)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetInternalElements2D(BH.oM.Geometry.IElement2D, System.Collections.Generic.List<BH.oM.Geometry.IElement2D>)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetInternalElements2D", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement2D>)})
+            },
+            {
+            "BH.Engine.Common.Modify.ISetOutlineElements1D(BH.oM.Geometry.IElement2D, System.Collections.Generic.List<BH.oM.Geometry.IElement1D>)",
+            typeof(BH.Engine.Spatial.Modify).GetMethod("ISetOutlineElements1D", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)})
+            },
+            {
+            "BH.Engine.Common.Query.Area(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Area", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.Bounds(BH.oM.Geometry.IElement0D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Bounds", new Type[] {typeof(BH.oM.Dimensional.IElement0D)})
+            },
+            {
+            "BH.Engine.Common.Query.Bounds(BH.oM.Geometry.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Bounds", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.Bounds(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Bounds", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IBounds(BH.oM.Geometry.IElement)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IBounds", new Type[] {typeof(BH.oM.Dimensional.IElement)})
+            },
+            {
+            "BH.Engine.Common.Query.IBounds(System.Collections.Generic.IEnumerable<BH.oM.Geometry.IElement>)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IBounds", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
+            },
+            {
+            "BH.Engine.Common.Query.Centroid(BH.oM.Geometry.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Centroid", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.Centroid(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Centroid", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.ControlPoints(BH.oM.Geometry.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ControlPoints", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.ControlPoints(BH.oM.Geometry.IElement2D, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ControlPoints", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.ElementCurves(BH.oM.Geometry.IElement1D, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementCurves", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.ElementCurves(BH.oM.Geometry.IElement2D, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementCurves", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.IElementCurves(BH.oM.Geometry.IElement, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElementCurves", new Type[] {typeof(BH.oM.Dimensional.IElement), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.IElementCurves(System.Collections.Generic.IEnumerable<BH.oM.Geometry.IElement>, System.Boolean)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElementCurves", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>), typeof(System.Boolean)})
+            },
+            {
+            "BH.Engine.Common.Query.ElementVertices(BH.oM.Geometry.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementVertices", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.ElementVertices(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementVertices", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IElementVertices(BH.oM.Geometry.IElement)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElementVertices", new Type[] {typeof(BH.oM.Dimensional.IElement)})
+            },
+            {
+            "BH.Engine.Common.Query.IElementVertices(System.Collections.Generic.IEnumerable<BH.oM.Geometry.IElement>)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElementVertices", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
+            },
+            {
+            "BH.Engine.Common.Query.IElements0D(BH.oM.Geometry.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IElements0D", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.IGeometry(BH.oM.Geometry.IElement0D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IGeometry", new Type[] {typeof(BH.oM.Dimensional.IElement0D)})
+            },
+            {
+            "BH.Engine.Common.Query.IGeometry(BH.oM.Geometry.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IGeometry", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.IInternalElements2D(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IInternalElements2D", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IInternalOutlineCurves(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IInternalOutlineCurves", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IsSelfIntersecting(BH.oM.Geometry.IElement1D, System.Double)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IsSelfIntersecting", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(System.Double)})
+            },
+            {
+            "BH.Engine.Common.Query.IsSelfIntersecting(BH.oM.Geometry.IElement2D, System.Double)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IsSelfIntersecting", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(System.Double)})
+            },
+            {
+            "BH.Engine.Common.Query.Length(BH.oM.Geometry.IElement1D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Length", new Type[] {typeof(BH.oM.Dimensional.IElement1D)})
+            },
+            {
+            "BH.Engine.Common.Query.Normal(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("Normal", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IOutlineElements1D(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineElements1D", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IOutlineCurve(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineCurve", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+            {
+            "BH.Engine.Common.Query.IOutlineCurve(System.Collections.Generic.List<BH.oM.Geometry.IElement1D>)",
+            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineCurve", new Type[] {typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)})
+            }
         };
 
         /***************************************************/

--- a/BHoMUpgrader31/MethodConverter.cs
+++ b/BHoMUpgrader31/MethodConverter.cs
@@ -41,6 +41,36 @@ namespace BH.Upgrader.v31
                 "BH.Engine.Geometry.Compute.ClipPolylines(BH.oM.Geometry.Polyline, BH.oM.Geometry.Polyline)",
                 typeof(BH.Engine.Geometry.Compute).GetMethod("BooleanIntersection", new Type[] { typeof(BH.oM.Geometry.Polyline), typeof(BH.oM.Geometry.Polyline), typeof(double) })
             },
+
+
+            {
+            "BH.Engine.Common.Create.INewElement0D(BH.oM.Dimensional.IElement1D, BH.oM.Geometry.Point)",
+            typeof(BH.Engine.Spatial.Create).GetMethod("INewElement0D", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(BH.oM.Geometry.Point)})
+            },
+            {
+            "BH.Engine.Common.Create.INewElement1D(BH.oM.Dimensional.IElement2D, BH.oM.Geometry.ICurve)",
+            typeof(BH.Engine.Spatial.Create).GetMethod("INewElement1D", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(BH.oM.Geometry.ICurve)})
+            },
+            {
+            "BH.Engine.Common.Create.INewInternalElement2D(BH.oM.Dimensional.IElement2D)",
+            typeof(BH.Engine.Spatial.Create).GetMethod("INewInternalElement2D", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+
+
+            {
+            "BH.Engine.Common.Create.INewElement0D(BH.oM.Geometry.IElement1D, BH.oM.Geometry.Point)",
+            typeof(BH.Engine.Spatial.Create).GetMethod("INewElement0D", new Type[] {typeof(BH.oM.Dimensional.IElement1D), typeof(BH.oM.Geometry.Point)})
+            },
+            {
+            "BH.Engine.Common.Create.INewElement1D(BH.oM.Geometry.IElement2D, BH.oM.Geometry.ICurve)",
+            typeof(BH.Engine.Spatial.Create).GetMethod("INewElement1D", new Type[] {typeof(BH.oM.Dimensional.IElement2D), typeof(BH.oM.Geometry.ICurve)})
+            },
+            {
+            "BH.Engine.Common.Create.INewInternalElement2D(BH.oM.Geometry.IElement2D)",
+            typeof(BH.Engine.Spatial.Create).GetMethod("INewInternalElement2D", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            },
+
+
             {
             "BH.Engine.Common.Compute.DistributeOutlines(System.Collections.Generic.List<System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>>, System.Boolean, System.Double)",
             typeof(BH.Engine.Spatial.Compute).GetMethod("DistributeOutlines", new Type[] {typeof(System.Collections.Generic.List<System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>>), typeof(System.Boolean), typeof(System.Double)})

--- a/BHoMUpgrader31/MethodConverter.cs
+++ b/BHoMUpgrader31/MethodConverter.cs
@@ -129,7 +129,7 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IBounds(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IBounds", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("Bounds", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
             },
             {
             "BH.Engine.Common.Query.Centroid(BH.oM.Dimensional.IElement1D)",
@@ -161,7 +161,7 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IElementCurves(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>, System.Boolean)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IElementCurves", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>), typeof(System.Boolean)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementCurves", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>), typeof(System.Boolean)})
             },
             {
             "BH.Engine.Common.Query.ElementVertices(BH.oM.Dimensional.IElement1D)",
@@ -177,7 +177,7 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IElementVertices(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IElementVertices", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementVertices", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
             },
             {
             "BH.Engine.Common.Query.IElements0D(BH.oM.Dimensional.IElement1D)",
@@ -197,7 +197,7 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IInternalOutlineCurves(BH.oM.Dimensional.IElement2D)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IInternalOutlineCurves", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("InternalOutlineCurves", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
             },
             {
             "BH.Engine.Common.Query.IsSelfIntersecting(BH.oM.Dimensional.IElement1D, System.Double)",
@@ -221,11 +221,11 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IOutlineCurve(BH.oM.Dimensional.IElement2D)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineCurve", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("OutlineCurve", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
             },
             {
             "BH.Engine.Common.Query.IOutlineCurve(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineCurve", new Type[] {typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("OutlineCurve", new Type[] {typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)})
             },
 
 
@@ -287,7 +287,7 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IBounds(System.Collections.Generic.IEnumerable<BH.oM.Geometry.IElement>)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IBounds", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("Bounds", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
             },
             {
             "BH.Engine.Common.Query.Centroid(BH.oM.Geometry.IElement1D)",
@@ -319,7 +319,7 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IElementCurves(System.Collections.Generic.IEnumerable<BH.oM.Geometry.IElement>, System.Boolean)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IElementCurves", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>), typeof(System.Boolean)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementCurves", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>), typeof(System.Boolean)})
             },
             {
             "BH.Engine.Common.Query.ElementVertices(BH.oM.Geometry.IElement1D)",
@@ -335,7 +335,7 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IElementVertices(System.Collections.Generic.IEnumerable<BH.oM.Geometry.IElement>)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IElementVertices", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("ElementVertices", new Type[] {typeof(System.Collections.Generic.IEnumerable<BH.oM.Dimensional.IElement>)})
             },
             {
             "BH.Engine.Common.Query.IElements0D(BH.oM.Geometry.IElement1D)",
@@ -355,7 +355,7 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IInternalOutlineCurves(BH.oM.Geometry.IElement2D)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IInternalOutlineCurves", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("InternalOutlineCurves", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
             },
             {
             "BH.Engine.Common.Query.IsSelfIntersecting(BH.oM.Geometry.IElement1D, System.Double)",
@@ -379,11 +379,11 @@ namespace BH.Upgrader.v31
             },
             {
             "BH.Engine.Common.Query.IOutlineCurve(BH.oM.Geometry.IElement2D)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineCurve", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("OutlineCurve", new Type[] {typeof(BH.oM.Dimensional.IElement2D)})
             },
             {
             "BH.Engine.Common.Query.IOutlineCurve(System.Collections.Generic.List<BH.oM.Geometry.IElement1D>)",
-            typeof(BH.Engine.Spatial.Query).GetMethod("IOutlineCurve", new Type[] {typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)})
+            typeof(BH.Engine.Spatial.Query).GetMethod("OutlineCurve", new Type[] {typeof(System.Collections.Generic.List<BH.oM.Dimensional.IElement1D>)})
             }
         };
 


### PR DESCRIPTION
### NOTE: Depends on 

https://github.com/BHoM/BHoM_Engine/pull/1498

### Issues addressed by this PR
Closes #
This contains both the converts for oM.Dimensional.IElement and oM.Geometry.IElement methods

### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/BHoM_Engine/pull/1498

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
With reference copy local = true, crashes otherwise
presumably due to being a `.exe`

Currently sounds like the changes which will enable this Versioning won't take effect til 3.2, in which case this should be in the BHoMUpgrader32...