### PR TITLE
Add upgrader for 3.2

### DIFF
--- a/BHoMUpgrader32/App.config
+++ b/BHoMUpgrader32/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/BHoMUpgrader32/BHoMUpgrader32.csproj
+++ b/BHoMUpgrader32/BHoMUpgrader32.csproj
@@ -36,12 +36,6 @@
     <Reference Include="BHoM">
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
     </Reference>
-    <Reference Include="Geometry_Engine">
-      <HintPath>..\..\BHoM_Engine\Build\Geometry_Engine.dll</HintPath>
-    </Reference>
-    <Reference Include="Geometry_oM">
-      <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/BHoMUpgrader32/BHoMUpgrader32.csproj
+++ b/BHoMUpgrader32/BHoMUpgrader32.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A6A4A1B7-0CE5-4104-8DB2-967D41F42754}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>BH.Upgrader.v32</RootNamespace>
+    <AssemblyName>BHoMUpgrader32</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\bin\BHoMUpgrader32\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BHoM">
+      <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
+    </Reference>
+    <Reference Include="Geometry_Engine">
+      <HintPath>..\..\BHoM_Engine\Build\Geometry_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Geometry_oM">
+      <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MethodConverter.cs" />
+    <Compile Include="ObjectConverter\_Interface.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TypeConverter.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BHoMUpgrader\BHoMUpgrader.csproj">
+      <Project>{47629a75-8509-491a-82e5-517a2d8b945e}</Project>
+      <Name>BHoMUpgrader</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/BHoMUpgrader32/MethodConverter.cs
+++ b/BHoMUpgrader32/MethodConverter.cs
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Upgrader.v32
+{
+    public partial class Converter
+    {
+        /***************************************************/
+        /**** Public Properties                         ****/
+        /***************************************************/
+
+        public Dictionary<string, MethodBase> ToNewMethod { get; set; } = new Dictionary<string, MethodBase>
+        {
+
+        };
+
+        /***************************************************/
+
+        public Dictionary<string, MethodBase> ToOldMethod { get; set; } = new Dictionary<string, MethodBase>
+        {
+
+        };
+
+        /***************************************************/
+    }
+}

--- a/BHoMUpgrader32/ObjectConverter/_Interface.cs
+++ b/BHoMUpgrader32/ObjectConverter/_Interface.cs
@@ -1,0 +1,99 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Upgrader.v32
+{
+    public partial class Converter : Base.IConverter
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public string PreviousVersion()
+        {
+            return "3.1";
+        }
+
+        /***************************************************/
+
+        public object IToNew(object item)
+        {
+            if (item == null)
+                return null;
+            else
+                return ToNew(item as dynamic);
+        }
+
+        /***************************************************/
+
+        public object IToOld(object item)
+        {
+            if (item == null)
+                return null;
+            else
+                return ToOld(item as dynamic);
+        }
+
+        /***************************************************/
+
+        public object IToNew(Dictionary<string, object> item, object typedObject)
+        {
+            if (item == null)
+                return null;
+            else
+                return ToNew(item, typedObject as dynamic);
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        public object ToNew(object item)
+        {
+            return null;
+        }
+
+        /***************************************************/
+
+        public object ToOld(object item)
+        {
+            return null;
+        }
+
+        /***************************************************/
+
+        public object ToNew(Dictionary<string, object> item, object typedObject)
+        {
+            return null;
+        }
+
+        /***************************************************/
+    }
+}

--- a/BHoMUpgrader32/Program.cs
+++ b/BHoMUpgrader32/Program.cs
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+
+namespace BH.Upgrader.v32
+{
+    static class Program
+    {
+        /***************************************************/
+        /**** Entry Methods                             ****/
+        /***************************************************/
+
+        static void Main(string[] args)
+        {
+            if (args.Length == 0)
+                return;
+
+            Base.Upgrader upgrader = new Base.Upgrader();
+            upgrader.ProcessingLoop(args[0], new Converter());
+        }
+
+        /***************************************************/
+    }
+}

--- a/BHoMUpgrader32/Properties/AssemblyInfo.cs
+++ b/BHoMUpgrader32/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BHoMUpgrader32")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BHoMUpgrader32")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("61c816c3-080c-481c-85f9-3ab3cffcd4b0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.2.0.0")]

--- a/BHoMUpgrader32/TypeConverter.cs
+++ b/BHoMUpgrader32/TypeConverter.cs
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Upgrader.v32
+{
+    public partial class Converter
+    {
+        /***************************************************/
+        /**** Public Properties                         ****/
+        /***************************************************/
+
+        public Dictionary<string, string> ToNewType { get; set; } = new Dictionary<string, string>
+        {
+
+        };
+
+        /***************************************************/
+
+        public Dictionary<string, string> ToOldType { get; set; } = new Dictionary<string, string>
+        {
+        };
+
+        /***************************************************/
+    }
+}

--- a/Versioning_Toolkit.sln
+++ b/Versioning_Toolkit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1000
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BHoMUpgrader30", "BHoMUpgrader30\BHoMUpgrader30.csproj", "{10D377C5-E17D-4135-A9AA-EB106833A94E}"
 EndProject
@@ -10,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Versioning_oM", "Versioning_oM\Versioning_oM.csproj", "{660D9A85-66B8-456B-B419-D3B176BBC66D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BHoMUpgrader31", "BHoMUpgrader31\BHoMUpgrader31.csproj", "{61C816C3-080C-481C-85F9-3AB3CFFCD4B0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BHoMUpgrader32", "BHoMUpgrader32\BHoMUpgrader32.csproj", "{A6A4A1B7-0CE5-4104-8DB2-967D41F42754}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{61C816C3-080C-481C-85F9-3AB3CFFCD4B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{61C816C3-080C-481C-85F9-3AB3CFFCD4B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{61C816C3-080C-481C-85F9-3AB3CFFCD4B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A6A4A1B7-0CE5-4104-8DB2-967D41F42754}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A6A4A1B7-0CE5-4104-8DB2-967D41F42754}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A6A4A1B7-0CE5-4104-8DB2-967D41F42754}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A6A4A1B7-0CE5-4104-8DB2-967D41F42754}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #53

This is literally a copy-paste of upgrader 3.1 where I changed the version number and emptied the dictionaries. 


### Test files
Take any file that requires a component to be upgraded and make sure that this is still working. Without this PR, you get a warning that BHoMUpgrader32.exe cannot be found.

If you don't have a script, you can find one here: https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Versioning_Toolkit?csf=1&e=76MDTD


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->