### PR TITLE
Only change type if it is being upgraded in GetTypeFromDic

### DIFF
--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -304,19 +304,20 @@ namespace BH.Upgrader.Base
 
         private static string GetTypeFromDic(Dictionary<string, string> dic, string type)
         {
-            if (type.Contains(","))
-                type = type.Split(',').First();
+            string unVersionedType = type;
+            if (unVersionedType.Contains(","))
+                unVersionedType = type.Split(',').First();
 
-            if (dic.ContainsKey(type))
-                return dic[type];
+            if (dic.ContainsKey(unVersionedType))
+                return dic[unVersionedType];
             else
             {
-                int index = type.LastIndexOf('.');
+                int index = unVersionedType.LastIndexOf('.');
                 if (index > 0)
                 {
-                    string ns = type.Substring(0, index);
+                    string ns = unVersionedType.Substring(0, index);
                     if (dic.ContainsKey(ns))
-                        return dic[ns] + type.Substring(index);
+                        return dic[ns] + unVersionedType.Substring(index);
                     else
                         return type;
                 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #61 

<!-- Add short description of what has been fixed -->

Making sure the type string returned is only modified if an upgrade is found in the dictionary, to ensure methods checking if the string has been modified function properly.

Might need extra protection as well, but this solves the immediate issue.

Without this, recursive triggering of earlier upgraders might not happen.

@adecler I am not sure if you wanted to solve this in another manner, but could be good to get this merged before anyway, to make to problem less urgent.

### Test files
<!-- Link to test files to validate the proposed changes -->

Adapter_Test script and other is test script folder here:

https://burohappold.sharepoint.com/:f:/s/BHoM/EnaQSQxOq7dGtNTv62vbcwUBSH0Sn6EUTV665Y0SXRY1VA?e=5Pjqf0

https://burohappold.sharepoint.com/:f:/s/BHoM/Ehi03DP0JRVKgczdKhGjaTEBsbgb1pTUORVARnYPAIcZcQ?e=xosZ8j

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->