### PR TITLE
Copy builds into ProgramData instead of Roaming

### DIFF
--- a/BHoMUpgrader30/BHoMUpgrader30.csproj
+++ b/BHoMUpgrader30/BHoMUpgrader30.csproj
@@ -91,4 +91,9 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /I /E "$(TargetDir)*.dll" C:\ProgramData\BHoM\Assemblies\bin\BHoMUpgrader30
+xcopy /Y /I /E "$(TargetDir)*.exe" C:\ProgramData\BHoM\Assemblies\bin\BHoMUpgrader30
+xcopy /Y /I /E "$(TargetDir)*.json" C:\ProgramData\BHoM\Assemblies\bin\BHoMUpgrader30</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/BHoMUpgrader31/BHoMUpgrader31.csproj
+++ b/BHoMUpgrader31/BHoMUpgrader31.csproj
@@ -60,4 +60,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /I /E "$(TargetDir)*.dll" C:\ProgramData\BHoM\Assemblies\bin\BHoMUpgrader31
+xcopy /Y /I /E "$(TargetDir)*.exe" C:\ProgramData\BHoM\Assemblies\bin\BHoMUpgrader31
+xcopy /Y /I /E "$(TargetDir)*.json" C:\ProgramData\BHoM\Assemblies\bin\BHoMUpgrader31</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/BHoMUpgrader32/BHoMUpgrader32.csproj
+++ b/BHoMUpgrader32/BHoMUpgrader32.csproj
@@ -60,4 +60,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /I /E "$(TargetDir)*.dll" C:\ProgramData\BHoM\Assemblies\bin\BHoMUpgrader32
+xcopy /Y /I /E "$(TargetDir)*.exe" C:\ProgramData\BHoM\Assemblies\bin\BHoMUpgrader32
+xcopy /Y /I /E "$(TargetDir)*.json" C:\ProgramData\BHoM\Assemblies\bin\BHoMUpgrader32</PostBuildEvent>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

https://github.com/BHoM/admin/issues/5

Only changes the target of the post-build copy command. This makes it possible to test that `UI_PostBuild.exe` is doing its job properly.


