### PR TITLE
Add versioning to Structural results

### DIFF
--- a/BHoMUpgrader32/Converter.cs
+++ b/BHoMUpgrader32/Converter.cs
@@ -49,9 +49,6 @@ namespace BH.Upgrader.v32
             ToNewObject.Add("BH.oM.Structure.Results.GlobalReactions", UpgradeResult);
             ToNewObject.Add("BH.oM.Structure.Results.ModalDynamics", UpgradeResult);
             ToNewObject.Add("BH.oM.Structure.Results.StructuralGlobalResult", UpgradeResult);
-            ToNewObject.Add("BH.oM.Structure.Results.MeshResultLayer", UpgradeResult);
-            ToNewObject.Add("BH.oM.Structure.Results.MeshResultSmoothingType", UpgradeResult);
-            ToNewObject.Add("BH.oM.Structure.Results.MeshResultType", UpgradeResult);
             ToNewObject.Add("BH.oM.Structure.Results.MeshDisplacement", UpgradeResult);
             ToNewObject.Add("BH.oM.Structure.Results.MeshForce", UpgradeResult);
             ToNewObject.Add("BH.oM.Structure.Results.MeshElementResult", UpgradeResult);

--- a/BHoMUpgrader32/Converter.cs
+++ b/BHoMUpgrader32/Converter.cs
@@ -97,7 +97,7 @@ namespace BH.Upgrader.v32
 
             //Serialisation_Engine is fallbacking to trying to de-serialise as CustomObject.
             //When doing so it might add GUID as a property, which needs to be removed if that is the case,
-            //as MeshResult is not a BHoMObejct and does not contain a BHoM_Guid.
+            //as MeshResult is not a BHoMObject and does not contain a BHoM_Guid.
             if (newVersion.ContainsKey("BHoM_Guid"))
                 newVersion.Remove("BHoM_Guid");
 

--- a/BHoMUpgrader32/Converter.cs
+++ b/BHoMUpgrader32/Converter.cs
@@ -55,7 +55,7 @@ namespace BH.Upgrader.v32
             ToNewObject.Add("BH.oM.Structure.Results.MeshDisplacement", UpgradeResult);
             ToNewObject.Add("BH.oM.Structure.Results.MeshForce", UpgradeResult);
             ToNewObject.Add("BH.oM.Structure.Results.MeshElementResult", UpgradeResult);
-            ToNewObject.Add("BH.oM.Structure.Results.MeshResult", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshResult", UpgradeMeshResult);
             ToNewObject.Add("BH.oM.Structure.Results.MeshStress", UpgradeResult);
             ToNewObject.Add("BH.oM.Structure.Results.MeshVonMises", UpgradeResult);
             ToNewObject.Add("BH.oM.Structure.Results.NodeAcceleration", UpgradeResult);
@@ -79,6 +79,27 @@ namespace BH.Upgrader.v32
 
             if (!newVersion.ContainsKey("ModeNumber"))
                 newVersion.Add("ModeNumber", -1);
+
+            return newVersion;
+        }
+
+        /***************************************************/
+
+        public static Dictionary<string, object> UpgradeMeshResult(Dictionary<string, object> result)
+        {
+            if (result == null)
+                return null;
+
+            Dictionary<string, object> newVersion = new Dictionary<string, object>(result);
+
+            if (!newVersion.ContainsKey("ModeNumber"))
+                newVersion.Add("ModeNumber", -1);
+
+            //Serialisation_Engine is fallbacking to trying to de-serialise as CustomObject.
+            //When doing so it might add GUID as a property, which needs to be removed if that is the case,
+            //as MeshResult is not a BHoMObejct and does not contain a BHoM_Guid.
+            if (newVersion.ContainsKey("BHoM_Guid"))
+                newVersion.Remove("BHoM_Guid");
 
             return newVersion;
         }

--- a/BHoMUpgrader32/Converter.cs
+++ b/BHoMUpgrader32/Converter.cs
@@ -95,6 +95,8 @@ namespace BH.Upgrader.v32
             //Serialisation_Engine is fallbacking to trying to de-serialise as CustomObject.
             //When doing so it might add GUID as a property, which needs to be removed if that is the case,
             //as MeshResult is not a BHoMObject and does not contain a BHoM_Guid.
+            //This fallback only happens when versioning is needed on property of the object,
+            //which is the case for the MeshResult that owns a list of MeshElementResults.
             if (newVersion.ContainsKey("BHoM_Guid"))
                 newVersion.Remove("BHoM_Guid");
 

--- a/BHoMUpgrader32/Converter.cs
+++ b/BHoMUpgrader32/Converter.cs
@@ -37,6 +37,32 @@ namespace BH.Upgrader.v32
         public Converter() : base()
         {
             PreviousVersion = "3.1";
+
+            ToNewObject.Add("BH.oM.Structure.Results.BarDisplacement", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.BarDeformation", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.BarForce", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.BarResult", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.BarStrain", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.BarStress", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.CompositeUtilisation", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.SteelUtilisation", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.GlobalReactions", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.ModalDynamics", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.StructuralGlobalResult", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshResultLayer", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshResultSmoothingType", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshResultType", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshDisplacement", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshForce", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshElementResult", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshResult", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshStress", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.MeshVonMises", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.NodeAcceleration", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.NodeDisplacement", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.NodeReaction", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.NodeResult", UpgradeResult);
+            ToNewObject.Add("BH.oM.Structure.Results.NodeVelocity", UpgradeResult);
         }
 
 
@@ -44,7 +70,20 @@ namespace BH.Upgrader.v32
         /**** Private Methods                           ****/
         /***************************************************/
 
+        public static Dictionary<string, object> UpgradeResult(Dictionary<string, object> result)
+        {
+            if (result == null)
+                return null;
+
+            Dictionary<string, object> newVersion = new Dictionary<string, object>(result);
+
+            if (!newVersion.ContainsKey("ModeNumber"))
+                newVersion.Add("ModeNumber", -1);
+
+            return newVersion;
+        }
 
         /***************************************************/
+
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM/pull/912
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->


<!-- Add short description of what has been fixed -->

Adds in `ModeNumber` as a property to structural results, if not found in the initial dictionary.

This is needed for the serialiser to be able to apply the correct creator map when trying to deserialise the results.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/Ep9h3lEyopBBvsnP3_HGzSwBncLyPKvZnn0q6AZBwMRwzA?e=j5DdEe

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->