### PR TITLE
Add versioning for FramingElements, fix bug in PostBuild and fix order of ObjectUpgrader

### DIFF
--- a/BHoMUpgrader33/Converter.cs
+++ b/BHoMUpgrader33/Converter.cs
@@ -36,7 +36,11 @@ namespace BH.Upgrader.v33
 
         public Converter() : base()
         {
-            PreviousVersion = "3.2"; 
+            PreviousVersion = "3.2";
+
+            ToNewObject.Add("BH.oM.Structure.FramingProperties.ConstantFramingElementProperty", UpgradeConstantFramingElementProperty);
+            ToNewObject.Add("BH.oM.Structure.Elements.FramingElement", UpgradeFramingElement);
+
         }
 
 
@@ -44,7 +48,89 @@ namespace BH.Upgrader.v33
         /**** Private Methods                           ****/
         /***************************************************/
 
+        public static Dictionary<string, object> UpgradeConstantFramingElementProperty(Dictionary<string, object> oldVersion)
+        {
+            if (oldVersion == null)
+                return null;
 
+            Dictionary<string, object> newVersion = new Dictionary<string, object>();
+
+            newVersion["_t"] = "BH.oM.Physical.FramingProperties.ConstantFramingProperty";
+            newVersion["OrientationAngle"] = oldVersion["OrientationAngle"];
+            newVersion["Name"] = oldVersion["Name"];
+            newVersion["CustomData"] = oldVersion["CustomData"];
+            newVersion["BHoM_Guid"] = oldVersion["BHoM_Guid"];
+            newVersion["Tags"] = oldVersion["Tags"];
+            newVersion["Fragments"] = oldVersion["Fragments"];
+
+            object sectionProp;
+            if (oldVersion.TryGetValue("SectionProperty", out sectionProp))
+            {
+                Dictionary<string, object> sectionDict = sectionProp as Dictionary<string, object>;
+                object profile;
+                if (sectionDict != null && sectionDict.TryGetValue("SectionProfile", out profile))
+                {
+                    newVersion["Profile"] = profile;
+                }
+
+                object strMaterial;
+                if (sectionDict != null && sectionDict.TryGetValue("Material", out strMaterial))
+                {
+                    Dictionary<string, object> strMatDict = strMaterial as Dictionary<string, object>;
+
+                    if (strMatDict != null)
+                    {
+                        Dictionary<string, object> material = new Dictionary<string, object>();
+                        material["_t"] = "BH.oM.Physical.Materials.Material";
+                        if (strMatDict.ContainsKey("Name"))
+                            material["Name"] = strMatDict["Name"];
+                        material["Properties"] = new List<object> { strMatDict };
+
+                        newVersion["Material"] = material;
+                    }
+                }
+            }
+
+            return newVersion;
+        }
+
+        /***************************************************/
+
+        public static Dictionary<string, object> UpgradeFramingElement(Dictionary<string, object> oldVersion)
+        {
+            if (oldVersion == null)
+                return null;
+
+            Dictionary<string, object> newVersion = new Dictionary<string, object>();
+
+            string type = "Beam";
+            object typeObject;
+            if (oldVersion.TryGetValue("StructuralUsage", out typeObject))
+                type = typeObject.ToString();
+
+            if(type == "Column")
+                newVersion["_t"] = "BH.oM.Physical.Elements.Column";
+            else if(type == "Brace")
+                newVersion["_t"] = "BH.oM.Physical.Elements.Bracing";
+            else if (type == "Cable")
+                newVersion["_t"] = "BH.oM.Physical.Elements.Cable";
+            else if (type == "Pile")
+                newVersion["_t"] = "BH.oM.Physical.Elements.Pile";
+            else
+                newVersion["_t"] = "BH.oM.Physical.Elements.Beam";
+
+
+
+            newVersion["Name"] = oldVersion["Name"];
+            newVersion["CustomData"] = oldVersion["CustomData"];
+            newVersion["BHoM_Guid"] = oldVersion["BHoM_Guid"];
+            newVersion["Tags"] = oldVersion["Tags"];
+            newVersion["Fragments"] = oldVersion["Fragments"];
+            newVersion["Location"] = oldVersion["LocationCurve"];
+            newVersion["Property"] = oldVersion["Property"];
+
+            return newVersion;
+        }
 
         /***************************************************/
 

--- a/PostBuild/CopyUpgrades.cs
+++ b/PostBuild/CopyUpgrades.cs
@@ -223,9 +223,11 @@ namespace PostBuild
             BsonDocument toNewContent = content["ToNew"] as BsonDocument;
             foreach (MethodBase method in Query.AllMethodList())
             {
-                PreviousVersionAttribute attribute = method.GetCustomAttribute<PreviousVersionAttribute>();
-                if (attribute != null && attribute.FromVersion == version)
-                    toNewContent.Add(new BsonElement(attribute.PreviousVersionAsText, BH.Engine.Serialiser.Convert.ToBson(method)));
+                foreach (PreviousVersionAttribute attribute in method.GetCustomAttributes<PreviousVersionAttribute>())
+                {
+                    if (attribute != null && attribute.FromVersion == version)
+                        toNewContent.Add(new BsonElement(attribute.PreviousVersionAsText, BH.Engine.Serialiser.Convert.ToBson(method)));
+                }
             }
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

Does not depend on, but done together with:
https://github.com/BHoM/BHoM/pull/959
https://github.com/BHoM/BHoM_Engine/pull/1916
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->


Closes #88 
Closes #89 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->

See https://github.com/BHoM/BHoM/pull/959 for test of Framing element upgrades

For General versioning test, see:

https://burohappold.sharepoint.com/:f:/s/BHoM/EopxQb5d9QdDqKoD--1178kBUpVHnKPZ1WWwyI2Eg1l18Q?e=1mkQkS

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Adds versioning for FramingElements and ConstantFramingProeprty from Structure_oM to Phsyical_oM, including slight obejct restructure
- Fix issue in postbuild, not allowing for more than one previous attribute
- Fix order ObjectUpgrade is preformed, to make sure full convert methods in the toolkit is prioerities, if they exist, over simpler type upgrade

### Additional comments
<!-- As required -->