### PR TITLE
Make sure property name is only last word, not including type name

### DIFF
--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -306,7 +306,10 @@ namespace BH.Upgrader.Base
             {
                 string key = oldType + "." + property.Name;
                 if (converter.ToNewProperty.ContainsKey(key))
-                    propertiesToChange.Add(property.Name, new BsonElement(converter.ToNewProperty[key], property.Value));
+                {
+                    string newPropName = converter.ToNewProperty[key].Split('.').Last();
+                    propertiesToChange.Add(property.Name, new BsonElement(newPropName, property.Value));
+                }
             }
             foreach (var kvp in propertiesToChange)
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #91 

<!-- Add short description of what has been fixed -->

Fixes a bug where the Property name upgrades got assigned the name of the class, including namespace + the new property name. Now changed to only pick out the last value.

### Test files
<!-- Link to test files to validate the proposed changes -->

Can be tested with https://github.com/BHoM/BHoM/pull/961


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->