### PR TITLE
Fixing Type collection error for versioning

### DIFF
--- a/BHoMUpgrader/Converter.cs
+++ b/BHoMUpgrader/Converter.cs
@@ -149,7 +149,7 @@ namespace BH.Upgrader.Base
                 if (toOld != null)
                 {
                     foreach (BsonElement element in toOld)
-                        ToNewType.Add(element.Name, element.Value.AsString);
+                        ToOldType.Add(element.Name, element.Value.AsString);
                 }
             }
         }


### PR DESCRIPTION

### Issues addressed by this PR
There was a type in the code that meant that a conversion entry in the Type dictionary that was supposed to be on `ToOld` ended up in `ToNew`, potentially creating infinite loop in very rare cases.

This one should be pretty obvious to review but shout if you disagree.