### PR TITLE
Migrate to version 4.0

### DIFF
--- a/BHoMUpgrader33/Upgrades.json
+++ b/BHoMUpgrader33/Upgrades.json
@@ -1,21 +1,678 @@
 ﻿{
   "Namespace": {
     "ToNew": {
+      "BH.oM.Environment.Gains": "BH.oM.Environment.SpaceCriteria",
+      "BH.UI.Components": "BH.UI.Base.Components",
+      "BH.Engine.CarbonQueryDatabase": "BH.Engine.Adapters.CarbonQueryDatabase",
+      "BH.oM.CarbonQueryDatabase": "BH.oM.Adapters.CarbonQueryDatabase",
+      "BH.oM.CFX.Settings": "BH.oM.CFD.CFX",
+      "BH.oM.Harpoon.Settings": "BH.oM.CFD.Harpoon",
+      "BH.Engine.HTTP": "BH.Engine.Adapters.HTTP",
+      "BH.oM.HTTP": "BH.oM.Adapters.HTTP",
+      "BH.Engine.OpenStreetMap": "BH.Engine.Adapters.OpenStreetMap",
+      "BH.oM.OpenStreetMap": "BH.oM.Adapters.OpenStreetMap",
+      "BH.Engine.Radiance": "BH.Engine.Adapters.Radiance",
+      "BH.oM.Radiance": "BH.oM.Adapters.Radiance"
     },
     "ToOld": {
+      "BH.oM.Environment.SpaceCriteria": "BH.oM.Environment.Gains",
+      "BH.UI.Base.Components": "BH.UI.Components",
+      "BH.Engine.Adapters.CarbonQueryDatabase": "BH.Engine.CarbonQueryDatabase",
+      "BH.oM.Adapters.CarbonQueryDatabase": "BH.oM.CarbonQueryDatabase",
+      "BH.oM.CFD.CFX": "BH.oM.CFX.Settings",
+      "BH.oM.CFD.Harpoon": "BH.oM.Harpoon.Settings",
+      "BH.Engine.Adapters.HTTP": "BH.Engine.HTTP",
+      "BH.oM.Adapters.HTTP": "BH.oM.HTTP",
+      "BH.Engine.Adapters.OpenStreetMap": "BH.Engine.OpenStreetMap",
+      "BH.oM.Adapters.OpenStreetMap": "BH.oM.OpenStreetMap",
+      "BH.Engine.Adapters.Radiance": "BH.Engine.Radiance",
+      "BH.oM.Adapters.Radiance": "BH.oM.Radiance"
     }
   },
   "Type": {
     "ToNew": {
-
+      "BH.oM.Climate.WeatherFile": "BH.oM.Environment.Climate.WeatherFile",
+      "BH.oM.Structure.Elements.FramingElement": "BH.oM.Physical.Elements.IFramingElement",
+      "BH.oM.Structure.FramingProperties.ConstantFramingElementProperty": "BH.oM.Physical.FramingProperties.ConstantFramingProperty",
+      "BH.oM.Structure.FramingProperties.IFramingElementProperty": "BH.oM.Physical.FramingProperties.IFramingElementProperty",
+      "BH.oM.Structure.Loads.Load`1": "BH.oM.Structure.Loads.IElementLoad`1",
+      "BH.oM.Adapters.ETABS.Elements.PierForce": "BH.oM.Adapters.ETABS.Results.PierForce"
     },
     "ToOld": {
-
+      "BH.oM.Environment.Climate.WeatherFile": "BH.oM.Climate.WeatherFile",
+      "BH.oM.Structure.Loads.IElementLoad`1": "BH.oM.Structure.Loads.Load`1",
+      "BH.oM.Adapters.ETABS.Results.PierForce": "BH.oM.Adapters.ETABS.Elements.PierForce"
     }
   },
   "Method": {
     "ToNew": {
-
+      "BH.UI.Components.MoveCaller.Move(BH.Adapter.BHoMAdapter, BH.Adapter.BHoMAdapter, BH.oM.Data.Requests.IRequest, System.Collections.Generic.Dictionary<System.String, System.Object>, System.Collections.Generic.Dictionary<System.String, System.Object>, System.Boolean)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.UI.Base.Components.MoveCaller, BHoM_UI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Move",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.BHoMAdapter, BHoM_Adapter, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.BHoMAdapter, BHoM_Adapter, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Data.Requests.IRequest\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.PullType\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.ActionConfig\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.PushType\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.ActionConfig\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.UI.Components.PullCaller.Pull(BH.Adapter.BHoMAdapter, BH.oM.Data.Requests.IRequest, System.Collections.Generic.Dictionary<System.String, System.Object>, System.Boolean)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.UI.Base.Components.PullCaller, BHoM_UI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Pull",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.BHoMAdapter, BHoM_Adapter, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.PullType\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.ActionConfig\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.UI.Components.DeleteCaller.Delete(BH.Adapter.BHoMAdapter, BH.oM.Data.Requests.FilterRequest, System.Collections.Generic.Dictionary<System.String, System.Object>, System.Boolean)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.UI.Base.Components.RemoveCaller, BHoM_UI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Remove",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.BHoMAdapter, BHoM_Adapter, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Data.Requests.IRequest\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.ActionConfig\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.UI.Components.PushCaller.Push(BH.Adapter.BHoMAdapter, System.Collections.Generic.IEnumerable<BH.oM.Base.IObject>, System.String, System.Collections.Generic.Dictionary<System.String, System.Object>, System.Boolean)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.UI.Base.Components.PushCaller, BHoM_UI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Push",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.BHoMAdapter, BHoM_Adapter, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.IEnumerable`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"System.Object, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.PushType\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.ActionConfig\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.UI.Components.ExecuteCaller.Execute(BH.Adapter.BHoMAdapter, System.String, System.Collections.Generic.Dictionary<System.String, System.Object>, System.Collections.Generic.Dictionary<System.String, System.Object>, System.Boolean)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.UI.Base.Components.ExecuteCaller, BHoM_UI, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Execute",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.BHoMAdapter, BHoM_Adapter, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.IExecuteCommand\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.ActionConfig\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Adapter.CFX.CFXAdapter(BH.oM.Adapter.FileSettings)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.CFD.CFXAdapter, CFX_Adapter, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": ".ctor",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.FileSettings\" }"
+        ]
+      },
+      "BH.Engine.Climate.Create.ExportEPW(BH.oM.Climate.WeatherFile, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Compute, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "ExportEPW",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Climate.WeatherFile\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Climate.Compute.ImportEpw(System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Compute, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "ImportEPW",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.DateTimeList(System.DateTime, System.DateTime, System.Int32)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Compute, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "DateTimeList",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.DateTime, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.DateTime, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.CullOverlaps(System.Collections.Generic.List<BH.oM.Environment.Element.Panel>)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Modify, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "CullOverlaps",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByElementID(System.Collections.Generic.List<BH.oM.Environment.Elements.Opening>, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByElementID",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByElementID(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByElementID",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Opening>, BH.oM.Geometry.SettingOut.Level)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.SettingOut.Level\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Opening>, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByMaximumLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Opening>, BH.oM.Geometry.SettingOut.Level)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByMaximumLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.SettingOut.Level\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByMaximumLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Opening>, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByMaximumLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByMinimumLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Opening>, BH.oM.Geometry.SettingOut.Level)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByMinimumLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.SettingOut.Level\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByMinimumLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Opening>, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByMinimumLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByName(System.Collections.Generic.List<BH.oM.Environment.Elements.Opening>, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByName",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.OpeningsByType(System.Collections.Generic.List<BH.oM.Environment.Elements.Opening>, BH.oM.Environment.Elements.OpeningType)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterOpeningsByType",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.OpeningType\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByElementID(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByElementID",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByGeometry(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, BH.oM.Geometry.ICurve)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByGeometry",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, BH.oM.Geometry.SettingOut.Level)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.SettingOut.Level\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByMaximumLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, BH.oM.Geometry.SettingOut.Level)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByMaximumLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.SettingOut.Level\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByMaximumLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByMaximumLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByMinimumLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, BH.oM.Geometry.SettingOut.Level)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByMinimumLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.SettingOut.Level\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByMinimumLevel(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByMinimumLevel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByName(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByName",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByTilt(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByTilt",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByTiltRange(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, System.Double, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByTiltRange",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsNotByType(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, BH.oM.Environment.Elements.PanelType)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsNotByType",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.PanelType\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.PanelsByType(System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>, BH.oM.Environment.Elements.PanelType)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterPanelsByType",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.Panel\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Elements.PanelType\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.ResultsByResultType(System.Collections.Generic.List<BH.oM.Environment.Results.SimulationResult>, BH.oM.Environment.Results.ProfileResultType": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterResultsByResultType",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.SimulationResult\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.ProfileResultType\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.ResultsByTypeUnitResultType(System.Collections.Generic.List<BH.oM.Environment.Results.SimulationResult>, BH.oM.Environment.Results.SimulationResultType, BH.oM.Environment.Results.ProfileResultUnit, BH.oM.Environment.Results.ProfileResultType": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterResultsByTypeUnitResultType",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.SimulationResult\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.SimulationResultType\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.ProfileResultUnit\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.ProfileResultType\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.ResultsByType(System.Collections.Generic.List<BH.oM.Environment.Results.SimulationResult>, BH.oM.Environment.Results.SimulationResultType": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterResultsByType",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.SimulationResult\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.SimulationResultType\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.ResultsByTypeUnit(System.Collections.Generic.List<BH.oM.Environment.Results.SimulationResult>, BH.oM.Environment.Results.SimulationResultType, BH.oM.Environment.Results.ProfileResultUnit": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterResultsByTypeUnit",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.SimulationResult\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.SimulationResultType\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.ProfileResultUnit\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.ResultsByUnit(System.Collections.Generic.List<BH.oM.Environment.Results.SimulationResult>, BH.oM.Environment.Results.ProfileResultUnit": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Environment.Query, Environment_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FilterResultsByUnit",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.SimulationResult\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Environment.Results.ProfileResultUnit\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.CullDuplicateLines(System.Collections.Generic.List<BH.oM.Geometry.Line>, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Geometry.Modify, Geometry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "CullDuplicateLines",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Line\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.PolyCurve)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Geometry.Query, Geometry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "DiscontinuityPoints",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.PolyCurve\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Geometry.Query.IDiscontinuityPoints(BH.oM.Geometry.ICurve)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Geometry.Query, Geometry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "IDiscontinuityPoints",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.ICurve)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Geometry.Query, Geometry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "DiscontinuityPoints",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Environment.Query.LongestSegmentLength(BH.oM.Geometry.Polyline)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Geometry.Query, Geometry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "LongestSegmentLength",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Polyline\" }"
+        ]
+      },
+      "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.Arc)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Geometry.Query, Geometry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "DiscontinuityPoints",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Arc\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.Circle)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Geometry.Query, Geometry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "DiscontinuityPoints",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Circle\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.Line)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Geometry.Query, Geometry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "DiscontinuityPoints",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Line\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Adapter.Harpoon.HarpoonAdapter(BH.oM.Adapter.FileSettings)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.CFD.HarpoonAdapter, Harpoon_Adapter, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": ".ctor",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapter.FileSettings\" }"
+        ]
+      },
+      "BH.Engine.Structure.Query.Geometry(BH.oM.Structure.Elements.FramingElement)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Physical.Query, Physical_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Geometry",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Physical.Elements.IFramingElement\" }"
+        ]
+      },
+      "BH.Engine.Spatial.Query.Centroid(BH.oM.Dimensional.IElement2D)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Spatial.Query, Spatial_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Centroid",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Dimensional.IElement2D\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Convert.ToFramingElement(BH.oM.Structure.Elements.Bar, BH.oM.Structure.Elements.StructuralUsage1D)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FramingElement",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.Elements.Bar\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.Elements.StructuralUsage1D\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.Panel(System.Collections.Generic.List<BH.oM.Structure.Elements.Edge>, System.Collections.Generic.List<BH.oM.Structure.Elements.Opening>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.Elements.Edge\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Vector\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.PanelPlanar(System.Collections.Generic.List<BH.oM.Structure.Elements.Edge>, System.Collections.Generic.List<BH.oM.Structure.Elements.Opening>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.Elements.Edge\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Vector\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.Panel(BH.oM.Geometry.ICurve, System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Vector\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.PanelPlanar(BH.oM.Geometry.ICurve, System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Vector\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.Panel(System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Vector\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.PanelPlanar(System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Vector\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.PanelPlanar(System.Collections.Generic.List<BH.oM.Geometry.Polyline>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Vector\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.Panel(BH.oM.Geometry.PlanarSurface, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.PlanarSurface\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Vector\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.PanelPlanar(System.Collections.Generic.List<BH.oM.Structure.Elements.Edge>, System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.Elements.Edge\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.PanelPlanar(BH.oM.Geometry.ICurve, System.Collections.Generic.List<BH.oM.Structure.Elements.Opening>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "Panel",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.ICurve\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.Elements.Opening\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.ConstantFramingElementProperty(BH.oM.Structure.SectionProperties.ISectionProperty, System.Double, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "ConstantFramingProperty",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SectionProperties.ISectionProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Create.FEMesh(BH.oM.Geometry.Mesh, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Create, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "FEMesh",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Mesh\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Structure.SurfaceProperties.ISurfaceProperty\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Vector\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Query.AnalyticalBars(BH.oM.Structure.Elements.FramingElement)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Query, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "AnalyticalBars",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Physical.Elements.IFramingElement\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      },
+      "BH.Engine.Structure.Query.AnalyticalBars(BH.oM.Structure.Elements.FramingElement, System.Double, System.Int32)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Structure.Query, Structure_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }",
+        "MethodName": "AnalyticalBars",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Physical.Elements.IFramingElement\" }] }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"
+        ]
+      }
     },
     "ToOld": {
 
@@ -23,10 +680,12 @@
   },
   "Property": {
     "ToNew": {
-
+      "BH.oM.Structure.Elements.RigidLink.MasterNode": "BH.oM.Structure.Elements.RigidLink.PrimaryNode",
+      "BH.oM.Structure.Elements.RigidLink.SlaveNodes": "BH.oM.Structure.Elements.RigidLink.SecondaryNodes"
     },
     "ToOld": {
-
+      "BH.oM.Structure.Elements.RigidLink.PrimaryNode": "BH.oM.Structure.Elements.RigidLink.MasterNode",
+      "BH.oM.Structure.Elements.RigidLink.SecondaryNodes": "BH.oM.Structure.Elements.RigidLink.SlaveNodes"
     }
   }
 }

--- a/BHoMUpgrader40/App.config
+++ b/BHoMUpgrader40/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/BHoMUpgrader40/BHoMUpgrader40.csproj
+++ b/BHoMUpgrader40/BHoMUpgrader40.csproj
@@ -4,10 +4,10 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8A2966F9-3E84-4F31-80D6-A33BDD3BAD95}</ProjectGuid>
+    <ProjectGuid>{77ECD961-7EA8-4237-B295-4D0B6EE492F8}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>BH.Upgrader.v33</RootNamespace>
-    <AssemblyName>BHoMUpgrader33</AssemblyName>
+    <RootNamespace>BH.Upgrader.v40</RootNamespace>
+    <AssemblyName>BHoMUpgrader40</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -58,11 +58,15 @@
       <Project>{47629a75-8509-491a-82e5-517a2d8b945e}</Project>
       <Name>BHoMUpgrader</Name>
     </ProjectReference>
+    <ProjectReference Include="..\PostBuild\PostBuild.csproj">
+      <Project>{4ec319a6-67c9-4627-9de6-046bb5bae401}</Project>
+      <Name>PostBuild</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Y /I /E "$(TargetDir)*.dll" C:\ProgramData\BHoM\Upgrades\BHoMUpgrader33
-xcopy /Y /I /E "$(TargetDir)BHoMUpgrader33.exe" C:\ProgramData\BHoM\Upgrades\BHoMUpgrader33
-xcopy /Y /I /E "$(TargetDir)Upgrades.json" C:\ProgramData\BHoM\Upgrades\BHoMUpgrader33</PostBuildEvent>
+    <PostBuildEvent>xcopy /Y /I /E "$(TargetDir)*.dll" C:\ProgramData\BHoM\Upgrades\BHoMUpgrader40
+xcopy /Y /I /E "$(TargetDir)BHoMUpgrader40.exe" C:\ProgramData\BHoM\Upgrades\BHoMUpgrader40
+call "$(TargetDir)PostBuild.exe" ..\..\..\ "C:\ProgramData\BHoM\Upgrades"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/BHoMUpgrader40/Converter.cs
+++ b/BHoMUpgrader40/Converter.cs
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Upgrader.v40
+{
+    public class Converter : Base.Converter
+    {
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public Converter() : base()
+        {
+            PreviousVersion = "3.3";
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+
+
+        /***************************************************/
+
+    }
+}

--- a/BHoMUpgrader40/Program.cs
+++ b/BHoMUpgrader40/Program.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Upgrader.v40
+{
+    static class Program
+    {
+        /***************************************************/
+        /**** Entry Methods                             ****/
+        /***************************************************/
+
+        static void Main(string[] args)
+        {
+            if (args.Length == 0)
+                return;
+
+            Base.Upgrader upgrader = new Base.Upgrader();
+            upgrader.ProcessingLoop(args[0], new Converter());
+        }
+
+        /***************************************************/
+    }
+}

--- a/BHoMUpgrader40/Properties/AssemblyInfo.cs
+++ b/BHoMUpgrader40/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BHoMUpgrader40")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BHoMUpgrader40")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("77ecd961-7ea8-4237-b295-4d0b6ee492f8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]

--- a/BHoMUpgrader40/Upgrades.json
+++ b/BHoMUpgrader40/Upgrades.json
@@ -1,0 +1,32 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Method": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Property": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  }
+}

--- a/Versioning_Toolkit.sln
+++ b/Versioning_Toolkit.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BHoMUpgrader33", "BHoMUpgra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostBuild", "PostBuild\PostBuild.csproj", "{4EC319A6-67C9-4627-9DE6-046BB5BAE401}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BHoMUpgrader40", "BHoMUpgrader40\BHoMUpgrader40.csproj", "{77ECD961-7EA8-4237-B295-4D0B6EE492F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{4EC319A6-67C9-4627-9DE6-046BB5BAE401}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4EC319A6-67C9-4627-9DE6-046BB5BAE401}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4EC319A6-67C9-4627-9DE6-046BB5BAE401}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77ECD961-7EA8-4237-B295-4D0B6EE492F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77ECD961-7EA8-4237-B295-4D0B6EE492F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77ECD961-7EA8-4237-B295-4D0B6EE492F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77ECD961-7EA8-4237-B295-4D0B6EE492F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #94

Getting the versioning toolkit ready for transition to BHoM 4.0.
You can find the procedure for this PR here: https://github.com/BHoM/Versioning_Toolkit/wiki/End-of-milestone-procedure

### Test files
Simply compile the versioning toolkit and make sure versioning is still working fine. I recommend:
- Create a fake `Versioning_44.json` in one of your project to make sure its content got captured into the final upgrader 4.0 `Upgrades.json` file.
- you run this twice: once without deleting the content of the Upgrades folder created by the installer and once by first deleting it.

Note that this will only work when the assembly versions have all been migrated to 4.0