### PR TITLE
Align with changes to Structure_oM with removal of EmbodiedCarbon from MaterialFragments

### DIFF
--- a/BHoMUpgrader40/Converter.cs
+++ b/BHoMUpgrader40/Converter.cs
@@ -43,6 +43,13 @@ namespace BH.Upgrader.v40
             ToNewObject.Add("BH.oM.Geometry.ShapeProfiles.TaperedProfile", UpgradeTaperedProfile);
             ToNewObject.Add("BH.oM.Environment.Gains.Profile", UpgradeProfile);
             ToNewObject.Add("BH.oM.Environment.Elements.Space", UpgradeSpace);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragment.Aluminium", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragment.Concrete", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragment.GenericIsoptropicMaterial", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragment.GenericOrthotropicMaterial", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragment.IMaterialFragment", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragment.Steel", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragment.Timber", UpgradeMaterialFragment);
         }
 
 
@@ -144,6 +151,21 @@ namespace BH.Upgrader.v40
             newSpace["Exhaust"] = new List<object> { space["Exhaust"] };
 
             return newSpace;
+        }
+
+        /***************************************************/
+
+        public static Dictionary<string, object> UpgradeMaterialFragment(Dictionary<string, object> materialFragment)
+        {
+            if (materialFragment == null)
+                return null;
+
+            Dictionary<string, object> newMaterialFragment = new Dictionary<string, object>(materialFragment);
+
+            if (newMaterialFragment.ContainsKey("EmbodiedCarbon"))
+                newMaterialFragment.Remove("EmbodiedCarbon");
+
+            return newMaterialFragment;
         }
     }
 }

--- a/BHoMUpgrader40/Converter.cs
+++ b/BHoMUpgrader40/Converter.cs
@@ -43,13 +43,13 @@ namespace BH.Upgrader.v40
             ToNewObject.Add("BH.oM.Geometry.ShapeProfiles.TaperedProfile", UpgradeTaperedProfile);
             ToNewObject.Add("BH.oM.Environment.Gains.Profile", UpgradeProfile);
             ToNewObject.Add("BH.oM.Environment.Elements.Space", UpgradeSpace);
-            ToNewObject.Add("BH.oM.Structure.MaterialFragment.Aluminium", UpgradeMaterialFragment);
-            ToNewObject.Add("BH.oM.Structure.MaterialFragment.Concrete", UpgradeMaterialFragment);
-            ToNewObject.Add("BH.oM.Structure.MaterialFragment.GenericIsoptropicMaterial", UpgradeMaterialFragment);
-            ToNewObject.Add("BH.oM.Structure.MaterialFragment.GenericOrthotropicMaterial", UpgradeMaterialFragment);
-            ToNewObject.Add("BH.oM.Structure.MaterialFragment.IMaterialFragment", UpgradeMaterialFragment);
-            ToNewObject.Add("BH.oM.Structure.MaterialFragment.Steel", UpgradeMaterialFragment);
-            ToNewObject.Add("BH.oM.Structure.MaterialFragment.Timber", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragments.Aluminium", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragments.Concrete", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragments.GenericIsoptropicMaterial", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragments.GenericOrthotropicMaterial", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragments.IMaterialFragment", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragments.Steel", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Structure.MaterialFragments.Timber", UpgradeMaterialFragment);
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1121

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/Structure_oM/Issue1070-RemoveEmbodiedCarbonFromMaterialFragments?csf=1&web=1&e=A2B66W

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added versioning for `MaterialFragments` for 4.0 and beyond
