### PR TITLE
Versioning added for FamilyLibrary

### DIFF
--- a/BHoMUpgrader40/Converter.cs
+++ b/BHoMUpgrader40/Converter.cs
@@ -51,7 +51,6 @@ namespace BH.Upgrader.v40
             ToNewObject.Add("BH.oM.Structure.MaterialFragments.Steel", UpgradeMaterialFragment);
             ToNewObject.Add("BH.oM.Structure.MaterialFragments.Timber", UpgradeMaterialFragment);
             ToNewObject.Add("BH.oM.Adapters.Revit.FamilyLibrary", UpgradeFamilyLibrary);
-            ToNewObject.Add("BH.oM.Adapters.Revit.Elements.ViewPlan", UpgradeViewPlan);
         }
 
 

--- a/BHoMUpgrader40/Converter.cs
+++ b/BHoMUpgrader40/Converter.cs
@@ -50,6 +50,8 @@ namespace BH.Upgrader.v40
             ToNewObject.Add("BH.oM.Structure.MaterialFragments.IMaterialFragment", UpgradeMaterialFragment);
             ToNewObject.Add("BH.oM.Structure.MaterialFragments.Steel", UpgradeMaterialFragment);
             ToNewObject.Add("BH.oM.Structure.MaterialFragments.Timber", UpgradeMaterialFragment);
+            ToNewObject.Add("BH.oM.Adapters.Revit.FamilyLibrary", UpgradeFamilyLibrary);
+            ToNewObject.Add("BH.oM.Adapters.Revit.Elements.ViewPlan", UpgradeViewPlan);
         }
 
 
@@ -167,5 +169,37 @@ namespace BH.Upgrader.v40
 
             return newMaterialFragment;
         }
+
+        /***************************************************/
+
+        public static Dictionary<string, object> UpgradeFamilyLibrary(Dictionary<string, object> familyLibrary)
+        {
+            if (familyLibrary == null)
+                return null;
+
+            Dictionary<string, object> newFamilyLibrary = new Dictionary<string, object>(familyLibrary);
+
+            if (newFamilyLibrary.ContainsKey("Dictionary"))
+                newFamilyLibrary.Remove("Dictionary");
+
+            return newFamilyLibrary;
+        }
+
+        /***************************************************/
+
+        public static Dictionary<string, object> UpgradeViewPlan(Dictionary<string, object> viewPlan)
+        {
+            if (viewPlan == null)
+                return null;
+
+            Dictionary<string, object> newViewPlan = new Dictionary<string, object>(viewPlan);
+
+            if (newViewPlan.ContainsKey("IsTemplate"))
+                newViewPlan.Remove("IsTemplate");
+
+            return newViewPlan;
+        }
+
+        /***************************************************/
     }
 }

--- a/BHoMUpgrader40/Converter.cs
+++ b/BHoMUpgrader40/Converter.cs
@@ -181,23 +181,8 @@ namespace BH.Upgrader.v40
 
             if (newFamilyLibrary.ContainsKey("Dictionary"))
                 newFamilyLibrary.Remove("Dictionary");
-
+            
             return newFamilyLibrary;
-        }
-
-        /***************************************************/
-
-        public static Dictionary<string, object> UpgradeViewPlan(Dictionary<string, object> viewPlan)
-        {
-            if (viewPlan == null)
-                return null;
-
-            Dictionary<string, object> newViewPlan = new Dictionary<string, object>(viewPlan);
-
-            if (newViewPlan.ContainsKey("IsTemplate"))
-                newViewPlan.Remove("IsTemplate");
-
-            return newViewPlan;
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #113

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
File created on 3.3 Beta uploaded [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FVersioning%5FToolkit%2F%23113%2DRevitToolkitTypeVersioning%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FVersioning%5FToolkit) - after the fix, the objects should not be `CustomObjects` any more.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- versioning added for `BH.oM.Adapters.Revit.Settings.FamilyLoadSettings`

### Additional comments
<!-- As required -->