### PR TITLE
Fix Upgrader for Space

### DIFF
--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -324,7 +324,7 @@ namespace BH.Upgrader.Base
                 if (prop != null)
                 {
                     BsonDocument upgrade = UpgradeLocally(prop, converter);
-                    if (upgrade != null)
+                    if (upgrade != null && prop != upgrade)
                         propertiesToUpgrade.Add(propName, upgrade);
                 }
             }

--- a/BHoMUpgrader40/Converter.cs
+++ b/BHoMUpgrader40/Converter.cs
@@ -21,6 +21,7 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -140,16 +141,33 @@ namespace BH.Upgrader.v40
 
         public static Dictionary<string, object> UpgradeSpace(Dictionary<string, object> space)
         {
-            if (space == null)
+            if (space == null || !space.ContainsKey("LightingGain") || 
+                !space.ContainsKey("EquipmentGain") || !space.ContainsKey("PeopleGain") || 
+                !space.ContainsKey("Infiltration") || !space.ContainsKey("Infiltration") || 
+                !space.ContainsKey("Ventilation") || !space.ContainsKey("Exhaust"))
                 return null;
 
             Dictionary<string, object> newSpace = new Dictionary<string, object>(space);
-            newSpace["LightingGain"] = new List<object> { space["LightingGain"] };
-            newSpace["EquipmentGain"] = new List<object> { space["EquipmentGain"] };
-            newSpace["PeopleGain"] = new List<object> { space["PeopleGain"] };
-            newSpace["Infiltration"] = new List<object> { space["Infiltration"] };
-            newSpace["Ventilation"] = new List<object> { space["Ventilation"] };
-            newSpace["Exhaust"] = new List<object> { space["Exhaust"] };
+
+            foreach (Dictionary<string, object> prop in space.Values.OfType <Dictionary<string, object>>())
+            {
+                if (prop.ContainsKey("_t"))
+                {
+                    string t = prop["_t"] as string;
+                    prop["_t"] = t.Replace("BH.oM.Environment.Gains", "BH.oM.Environment.SpaceCriteria")
+                                  .Replace("BH.oM.Environment.Ventilation", "BH.oM.Environment.SpaceCriteria");
+                }
+
+                if (prop.ContainsKey("Profile"))
+                    prop["Profile"] = UpgradeProfile(prop["Profile"] as Dictionary<string, object>);
+            }
+
+            List<string> propToFix = new List<string> { "LightingGain", "EquipmentGain", "PeopleGain", "Infiltration", "Ventilation", "Exhaust" };
+            foreach (string prop in propToFix)
+            {
+                if (!space[prop].GetType().IsArray)
+                    newSpace[prop] = new List<object> { space[prop] };
+            }
 
             return newSpace;
         }


### PR DESCRIPTION
   
### Issues addressed by this PR
Follow up on https://github.com/BHoM/BHoM_Engine/pull/2241

As mentioned in that PR, the `BH.oM.Environment.Elements.Space` objects from version 3.2 crashe the UI after the PR was merged. Since the problem occurs only for the `Space` class, I decided to fix its upgrader instead of finding an alternative solution to what was removed by that PR. 

Overall, the problem we are facing right now will be solved once we switch to forward versioning so I think this is good enough for the beta as versioning will be frozen for 4.0 anyways. So no risk of new types upgrades creeping up. 

Also notice, I have added a tiny change on the `Upgrader` code. This is because I noticed that the upgrader from previous versions were not called as often as they should have. The problem was that the new code added recently in that  function was considering properties updated event as if they weren't as long as they were not upgraded to null (default behaviour when the versioning founds nothing). The change should make sense on its own by just looking at the code but happy to run you through it in more details. 


### Test files
I have ran the combination of the current mater (including yesterday's fix PR) with the changes here and it worked successfully on all items from the versioning CI verification, the seriliasation CI verification and all items from the existing datasets. Obviously there are some items that return as Custom objects as they were already doing that. But no new item was added to the failing list and, more importantly, nothing was crashing. 

### Additional comments
The example of failing Space I had provided in yesterday's PR is still returning as custom object **_UNLESS_** you manually replace the profile types in the json from `Ventilation` to a valid enum. I have no idea why `Ventilation` is not in the list of profile types anymore nor what I should replace it with so I let you be the judge of that. Personally, as long as the UI is not crashing and the Versioning framework works as expected I am happy. 