### PR TITLE
Add versioning for ConcreteSection objects

### DIFF
--- a/BHoMUpgrader43/Converter.cs
+++ b/BHoMUpgrader43/Converter.cs
@@ -38,7 +38,8 @@ namespace BH.Upgrader.v43
         public Converter() : base()
         {
             PreviousVersion = "4.2";
-
+			
+            ToNewObject.Add("BH.oM.Structure.SectionProperties.ConcreteSection", UpgradeConcreteSection);
             ToNewObject.Add("BH.oM.MEP.System.CableTray", UpgradeCableTray);
             ToNewObject.Add("BH.oM.Adapters.Revit.Parameters.RevitIdentifiers", UpgradeRevitIdentifiers);
         }
@@ -47,6 +48,32 @@ namespace BH.Upgrader.v43
         /***************************************************/
         /**** Private Methods                           ****/
         /***************************************************/
+
+        public static Dictionary<string, object> UpgradeConcreteSection(Dictionary<string, object> oldVersion)
+        {
+            Dictionary<string, object> newVersion = new Dictionary<string, object>(oldVersion);
+
+            Dictionary<string, object> barRebarIntent = new Dictionary<string, object>();
+            barRebarIntent["_t"] = "BH.oM.Structure.Reinforcement.BarRebarIntent";
+
+            barRebarIntent["BarReinforcement"] = "[]";
+            if (newVersion.ContainsKey("Reinforcement"))
+            {
+                barRebarIntent["BarReinforcement"] = newVersion["Reinforcement"];
+                newVersion.Remove("Reinforcement");
+            }
+			
+			barRebarIntent["MinimumCover"] = "";
+            if (newVersion.ContainsKey("MinimumCover"))
+            {
+                barRebarIntent["MinimumCover"] = newVersion["MinimumCover"];
+                newVersion.Remove("MinimumCover");
+            }
+			
+			newVersion.Add("RebarIntent", barRebarIntent);
+
+            return newVersion;
+		}
 
         private static Dictionary<string, object> UpgradeCableTray(Dictionary<string, object> oldVersion)
         {
@@ -60,8 +87,6 @@ namespace BH.Upgrader.v43
 
             return newVersion;
         }
-
-        /***************************************************/
 
         private static Dictionary<string, object> UpgradeRevitIdentifiers(Dictionary<string, object> oldVersion)
         {
@@ -80,6 +105,8 @@ namespace BH.Upgrader.v43
         }
 
         /***************************************************/
+
+
     }
 }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1255
https://github.com/BHoM/BHoM_Engine/pull/2528
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #168 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/Versioning_Toolkit/%23168-ConcreteSectionUpgrade.gh?csf=1&web=1&e=YqA4Bo

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added versioning for `ConcreteSection` to maintain the `Reinforcement` and `MinimumCover` when upgrading to `BarRebarIntent` objects