### PR TITLE
Fix issues with verification for fallback type

### DIFF
--- a/.ci/code/Versioning_Test/Helpers/CanReplaceMethodWithType.cs
+++ b/.ci/code/Versioning_Test/Helpers/CanReplaceMethodWithType.cs
@@ -66,14 +66,14 @@ namespace BH.Test.Versioning
             if (m_TypeDic.Count == 0)
             {
                 m_TypeDic = Engine.Reflection.Query.BHoMTypeList()
-                    .GroupBy(x => x.Namespace.Split(new char[] { '.' })[2])
+                    .GroupBy(x => x.Namespace.NameSpaceKey())
                     .ToDictionary(x => x.Key, x => x.ToList());
             }
 
             if (!typeName.EndsWith("Create"))
                 return null;
 
-            string key = typeName.Split(new char[] { '.' })[2];
+            string key = typeName.NameSpaceKey();
             List<Type> types = new List<Type>();
             if (m_TypeDic.ContainsKey(key))
                 types = m_TypeDic[key];
@@ -93,6 +93,16 @@ namespace BH.Test.Versioning
             return match;
         }
 
+        /*************************************/
+
+        private static string NameSpaceKey(this string typeName)
+        {
+            string[] splitNamespace = typeName.Split(new char[] { '.' });
+            string key = splitNamespace[2];
+            if (key == "Adapters" && splitNamespace.Length > 3)
+                key += "." + splitNamespace[3];
+            return key;
+        }
 
         /*************************************/
         /**** Private Methods             ****/

--- a/.ci/code/Versioning_Test/Helpers/CanReplaceMethodWithType.cs
+++ b/.ci/code/Versioning_Test/Helpers/CanReplaceMethodWithType.cs
@@ -81,6 +81,8 @@ namespace BH.Test.Versioning
             Type match = null;
             //Splitting by ` to acount for generics
             List<Type> matches = types.Where(x => x.Name.Split('`')[0] == methodName).ToList();
+            if (matches.Count == 1)
+                match = matches.First();
 
             return match;
         }

--- a/.ci/code/Versioning_Test/Helpers/CanReplaceMethodWithType.cs
+++ b/.ci/code/Versioning_Test/Helpers/CanReplaceMethodWithType.cs
@@ -79,16 +79,8 @@ namespace BH.Test.Versioning
                 types = m_TypeDic[key];
 
             Type match = null;
-            List<Type> matches = types.Where(x => x.Name == methodName).ToList();
-            if (matches.Count == 1)
-                match = matches.First();
-
-            if (match == null)
-            {
-                matches = types.Where(x => x.Name.StartsWith(methodName)).ToList();
-                if (matches.Count == 1)
-                    match = matches.First();
-            }
+            //Splitting by ` to acount for generics
+            List<Type> matches = types.Where(x => x.Name.Split('`')[0] == methodName).ToList();
 
             return match;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #180

<!-- Add short description of what has been fixed -->

Fixing two issues with the fallback type
- Fixes the grouping by namespace to make sure adapter namespaces are appropriately grouped
- Changing the checking of exact match or StartsWith to instead splitting by generics sign and only check for exact match

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EjFXfSKJ2mlNmQMbHWWXH4sBwNWOSNPgpdK3uhRk4v1jfw?e=ZcswlC

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->