### PR TITLE
PostBuild tweaked to allow versioning of the Revit assemblies

### DIFF
--- a/PostBuild/CopyUpgrades.cs
+++ b/PostBuild/CopyUpgrades.cs
@@ -67,7 +67,7 @@ namespace PostBuild
                 ReadVersioningFile(file, versioning);
 
             // Get versioning from attributes
-            Compute.LoadAllAssemblies(Query.BHoMFolder());
+            Compute.LoadAllAssemblies(Query.BHoMFolder(), "oM|_Engine|_Adapter");
             CollectMethodVersioning(versioning["Method"] as BsonDocument);
 
             // return upgrade document
@@ -243,7 +243,7 @@ namespace PostBuild
             {
                 foreach (PreviousVersionAttribute attribute in method.GetCustomAttributes<PreviousVersionAttribute>())
                 {
-                    if (attribute != null && attribute.FromVersion == version)
+                    if (attribute != null && attribute.FromVersion == version && toNewContent.All(x => x.Name != attribute.PreviousVersionAsText))
                         toNewContent.Add(new BsonElement(attribute.PreviousVersionAsText, BH.Engine.Serialiser.Convert.ToBson(method)));
                 }
             }

--- a/PostBuild/CopyUpgrades.cs
+++ b/PostBuild/CopyUpgrades.cs
@@ -67,7 +67,7 @@ namespace PostBuild
                 ReadVersioningFile(file, versioning);
 
             // Get versioning from attributes
-            Compute.LoadAllAssemblies(Query.BHoMFolder(), "oM|_Engine|_Adapter");
+            Compute.LoadAllAssemblies(Query.BHoMFolder(), "BHoM|_oM|_Engine|_Adapter");
             CollectMethodVersioning(versioning["Method"] as BsonDocument);
 
             // return upgrade document
@@ -243,8 +243,16 @@ namespace PostBuild
             {
                 foreach (PreviousVersionAttribute attribute in method.GetCustomAttributes<PreviousVersionAttribute>())
                 {
-                    if (attribute != null && attribute.FromVersion == version && toNewContent.All(x => x.Name != attribute.PreviousVersionAsText))
+                    if (attribute != null && attribute.FromVersion == version)
+                    {
+                        // Remove the existing element with same name if it exists
+                        int indexOfExisting = toNewContent.IndexOfName(attribute.PreviousVersionAsText);
+                        if (indexOfExisting != -1)
+                            toNewContent.RemoveAt(indexOfExisting);
+
+                        // Add new element
                         toNewContent.Add(new BsonElement(attribute.PreviousVersionAsText, BH.Engine.Serialiser.Convert.ToBson(method)));
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #191

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
1. Switch Revit_Toolkit to branch with the same name as this
2. Build Revit_Toolkit in a few solution configs
3. Build Versioning_Toolkit
4. Check if C:\ProgramData\BHoM\Upgrades\BHoMUpgrader52\Upgrades.json contains `Method.ToNew.TestMethod`

Actual versioning will of course only work in the Revit context - but this PR is meant to enable capturing the attributes from Revit assemblies and putting their owners in Upgrades.json, no more than that.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
**Do not merge Revit_Toolkit branch** - it should be deleted once this PR gets tested & approved!