### PR TITLE
Enable Versioning checks to decide between running all versions or just the latest

### DIFF
--- a/.ci/code/Versioning_Test/Verify/FromJson.cs
+++ b/.ci/code/Versioning_Test/Verify/FromJson.cs
@@ -44,10 +44,14 @@ namespace BH.Test.Versioning
         /**** Test Methods                ****/
         /*************************************/
 
-        public static TestResult FromJsonDatasets()
+        public static TestResult FromJsonDatasets(bool testAll = false)
         {
+            System.Threading.Thread.Sleep(5000);
             string testFolder = @"C:\ProgramData\BHoM\Datasets\TestSets\Versioning";
-            List<string> versions = new List<string> { "5.2", "5.1", "5.0", "4.3", "4.2", "4.1", "4.0", "3.3" };
+            List<string> versions = new List<string> { "5.2", };
+            if(testAll)
+                versions.AddRange(new List<string> { "5.1", "5.0", "4.3", "4.2", "4.1", "4.0", "3.3" });
+
             string exceptions = "Grasshopper|Rhinoceros";
 
             // Test all the BHoM versions available

--- a/.ci/code/Versioning_Test/Verify/FromJson.cs
+++ b/.ci/code/Versioning_Test/Verify/FromJson.cs
@@ -46,7 +46,6 @@ namespace BH.Test.Versioning
 
         public static TestResult FromJsonDatasets(bool testAll = false)
         {
-            System.Threading.Thread.Sleep(5000);
             string testFolder = @"C:\ProgramData\BHoM\Datasets\TestSets\Versioning";
             List<string> versions = new List<string> { "5.2", };
             if(testAll)


### PR DESCRIPTION
Aims to speed up Versioning checks on PRs by allowing only the latest version to be tested against, with all versions saved for overnight builds.