### PR TITLE
Lusas toolkit #315 add method modifying merging tolerance

### DIFF
--- a/BHoMUpgrader70/Converter.cs
+++ b/BHoMUpgrader70/Converter.cs
@@ -49,32 +49,8 @@ namespace BH.Upgrader.v70
 
         public static Dictionary<string, object> UpgradeLusasConfig(Dictionary<string, object> oldVersion)
         {
-            Dictionary<string, object> newVersion = new Dictionary<string, object>();
+            Dictionary<string, object> newVersion = new Dictionary<string, object>(oldVersion);
             newVersion["_t"] = "BH.oM.Adapters.Lusas.LusasSettings";
-
-            /*oldVersion.Remove("BHoM_Guid");
-            oldVersion.Remove("Name");
-            oldVersion.Remove("Fragments");
-            oldVersion.Remove("Tags");
-            oldVersion.Remove("CustomData");*/
-
-            newVersion["MergeTolerance"] = double.NaN;
-            newVersion["LibrarySettings"] = oldVersion["LibrarySettings"];
-            newVersion["WrapNonBHoMObjects"] = false;
-            newVersion["DefaultPushType"] = 0;
-            newVersion["CloneBeforePush"] = true;
-            newVersion["DefaultPullType"] = 0;
-            newVersion["HandleDependencies"] = true;
-            newVersion["UseAdapterId"] = true;
-            newVersion["UseHashComparerAsDefault"] = true;
-            newVersion["ProcessInMemory"] = false;
-            newVersion["OnlyUpdateChangedObjects"] = true;
-            newVersion["CacheCRUDobjects"] = true;
-            newVersion["CreateOnly_DistinctObjects"] = false;
-            newVersion["CreateOnly_DistinctDependencies"] = true;
-
-            if (newVersion.ContainsKey("BHoM_Guid"))
-                newVersion.Remove("BHoM_Guid");
 
             return newVersion;
         }

--- a/BHoMUpgrader70/Converter.cs
+++ b/BHoMUpgrader70/Converter.cs
@@ -39,6 +39,41 @@ namespace BH.Upgrader.v70
         public Converter() : base()
         {
             PreviousVersion = "6.3";
+
+            ToNewObject.Add("BH.oM.Adaters.Lusas.LusasConfig", UpgradeLusasConfig);
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        public static Dictionary<string, object> UpgradeLusasConfig(Dictionary<string, object> old)
+        {
+            Dictionary<string, object> librarySettings = new Dictionary<string, object>();
+            if (old.ContainsKey("LibrarySettings"))
+            {
+                librarySettings["_t"] = "BH.oM.Adapters.Lusas.LibrarySettings";
+                librarySettings["LibrarySettings"] = old["LibrarySettings"];
+            }
+
+            return new Dictionary<string, object>
+        {
+            { "_t",  "BH.oM.Adapters.Lusas.LusasSettings" },
+            { "MergeTolerance", double.NaN },
+            { "LibrarySettings", librarySettings },
+            { "WrapNonBHoMObjects", false },
+            { "DefaultPushType", null},
+            { "CloneBeforePush", true},
+            { "DefaultPullType", null},
+            { "HandleDependencies", true },
+            { "UseAdapterId", true },
+            { "UsaHashComparerAsDefault", true },
+            { "ProcessInMemory", false },
+            { "OnlyUpdateChangedObjects", true },
+            { "CacheCRUDobjects", true },
+            { "CreateOnly_DistinctObjects", false },
+            { "CreateOnly_DistinctDependencies", true },
+        };
         }
     }
 }

--- a/BHoMUpgrader70/Converter.cs
+++ b/BHoMUpgrader70/Converter.cs
@@ -40,40 +40,43 @@ namespace BH.Upgrader.v70
         {
             PreviousVersion = "6.3";
 
-            ToNewObject.Add("BH.oM.Adaters.Lusas.LusasConfig", UpgradeLusasConfig);
+            ToNewObject.Add("BH.oM.Adapters.Lusas.LusasConfig", UpgradeLusasConfig);
         }
 
         /***************************************************/
         /**** Private Methods                           ****/
         /***************************************************/
 
-        public static Dictionary<string, object> UpgradeLusasConfig(Dictionary<string, object> old)
+        public static Dictionary<string, object> UpgradeLusasConfig(Dictionary<string, object> oldVersion)
         {
-            Dictionary<string, object> librarySettings = new Dictionary<string, object>();
-            if (old.ContainsKey("LibrarySettings"))
-            {
-                librarySettings["_t"] = "BH.oM.Adapters.Lusas.LibrarySettings";
-                librarySettings["LibrarySettings"] = old["LibrarySettings"];
-            }
+            Dictionary<string, object> newVersion = new Dictionary<string, object>();
+            newVersion["_t"] = "BH.oM.Adapters.Lusas.LusasSettings";
 
-            return new Dictionary<string, object>
-        {
-            { "_t",  "BH.oM.Adapters.Lusas.LusasSettings" },
-            { "MergeTolerance", double.NaN },
-            { "LibrarySettings", librarySettings },
-            { "WrapNonBHoMObjects", false },
-            { "DefaultPushType", null},
-            { "CloneBeforePush", true},
-            { "DefaultPullType", null},
-            { "HandleDependencies", true },
-            { "UseAdapterId", true },
-            { "UsaHashComparerAsDefault", true },
-            { "ProcessInMemory", false },
-            { "OnlyUpdateChangedObjects", true },
-            { "CacheCRUDobjects", true },
-            { "CreateOnly_DistinctObjects", false },
-            { "CreateOnly_DistinctDependencies", true },
-        };
+            /*oldVersion.Remove("BHoM_Guid");
+            oldVersion.Remove("Name");
+            oldVersion.Remove("Fragments");
+            oldVersion.Remove("Tags");
+            oldVersion.Remove("CustomData");*/
+
+            newVersion["MergeTolerance"] = double.NaN;
+            newVersion["LibrarySettings"] = oldVersion["LibrarySettings"];
+            newVersion["WrapNonBHoMObjects"] = false;
+            newVersion["DefaultPushType"] = 0;
+            newVersion["CloneBeforePush"] = true;
+            newVersion["DefaultPullType"] = 0;
+            newVersion["HandleDependencies"] = true;
+            newVersion["UseAdapterId"] = true;
+            newVersion["UseHashComparerAsDefault"] = true;
+            newVersion["ProcessInMemory"] = false;
+            newVersion["OnlyUpdateChangedObjects"] = true;
+            newVersion["CacheCRUDobjects"] = true;
+            newVersion["CreateOnly_DistinctObjects"] = false;
+            newVersion["CreateOnly_DistinctDependencies"] = true;
+
+            if (newVersion.ContainsKey("BHoM_Guid"))
+                newVersion.Remove("BHoM_Guid");
+
+            return newVersion;
         }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/Lusas_Toolkit/pull/374
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #241 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `LusasConfig` object replaced with `LusasSettings`, properties are mapped;
- Additional input `mergingTolerance` included on `LusasSettings` object.

### Additional comments
<!-- As required -->