### PR TITLE
Tweaks to base upgrader and base Converter to work with direct calling rather than pipe system

### DIFF
--- a/BHoMUpgrader/Converter.cs
+++ b/BHoMUpgrader/Converter.cs
@@ -70,7 +70,7 @@ namespace BH.Upgrader.Base
 
         public Converter()
         {
-            string folder = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            string folder = Path.GetDirectoryName(Assembly.GetCallingAssembly().Location);
             LoadUpgrades(Path.Combine(folder, "Upgrades.json"));
         }
 

--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -105,21 +105,24 @@ namespace BH.Upgrader.Base
             if (document == null)
                 return null;
 
+            //Clone to ensure able to compare with original document
+            //Without this, the input document is changed as same reference
+            BsonDocument newDoc = new BsonDocument(document);   
             Console.WriteLine("document received: " + document.ToJson());
 
             BsonDocument result = null;
-            if (document.Contains("_t"))
+            if (newDoc.Contains("_t"))
             {
                 if (document["_t"] == "System.Reflection.MethodBase")
-                    result = UpgradeMethod(document, converter);
+                    result = UpgradeMethod(newDoc, converter);
                 else if (document["_t"] == "System.Type")
-                    result = UpgradeType(document, converter);
+                    result = UpgradeType(newDoc, converter);
                 else
-                    result = UpgradeObject(document, converter);
+                    result = UpgradeObject(newDoc, converter);
             }
-            else if(document.Contains("k") && document.Contains("v"))
+            else if(newDoc.Contains("k") && newDoc.Contains("v"))
             {
-                result = UpgradeObject(document, converter);
+                result = UpgradeObject(newDoc, converter);
             }
 
             return result;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM_Engine/pull/3332   

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->


<!-- Add short description of what has been fixed -->

Small tweaks to the base Converter and upgrader to be able to directly call the versioning, skipping over the pipes.

Please see Engine PR for more details.

Assembly path change:
Change required when directly calling the converts on the main process.
Making this change on the base Converter should work for both pipe system as well as new intended system, as the calling assembly for the base converter always will be the concrete converter for a particular version, hence the folder that the for example BHoMUpgrader72.exe lives in.

Added cloning:
Required to ensure able to check newDoc == document as without doing this, the entry document will be changed when changing properties.

On previous system this was not requires as it was implicitly deep cloned via the serialisation required when sending via pipes.

### Test files
<!-- Link to test files to validate the proposed changes -->

See BHoM_Engine PR


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->