### PR TITLE
Turn off console logging by default

### DIFF
--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -39,19 +39,28 @@ namespace BH.Upgrader.Base
     public class Upgrader
     {
         /***************************************************/
+        /**** Public Properties                         ****/
+        /***************************************************/
+
+        public virtual bool LogToConsole { get; set; } = false;
+
+        /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
 
         public void ProcessingLoop(string pipeName, Converter converter)
         {
+            LogToConsole = true;
             // Make sure all assemblies are loaded
             AssemblyName[] assemblies = Assembly.GetEntryAssembly().GetReferencedAssemblies();
             foreach (AssemblyName assembly in assemblies)
             {
                 Assembly.Load(assembly);
-                Console.WriteLine("Assembly Loaded: " + assembly.Name);
+                if(LogToConsole)
+                    Console.WriteLine("Assembly Loaded: " + assembly.Name);
             }
-            Console.WriteLine("");
+            if(LogToConsole)
+                Console.WriteLine("");
 
             NamedPipeClientStream pipe = null;
 
@@ -72,7 +81,7 @@ namespace BH.Upgrader.Base
                     try
                     {
                         BsonDocument doc = ReadDocument(reader);
-                        if (doc != null)
+                        if (LogToConsole && doc != null)
                             Console.WriteLine("document received: " + doc.ToJson());
                         newDoc = Upgrade(doc, converter);
                     }
@@ -108,7 +117,8 @@ namespace BH.Upgrader.Base
             //Clone to ensure able to compare with original document
             //Without this, the input document is changed as same reference
             BsonDocument newDoc = new BsonDocument(document);   
-            Console.WriteLine("document received: " + document.ToJson());
+            if(LogToConsole)
+                Console.WriteLine("document received: " + document.ToJson());
 
             BsonDocument result = null;
             if (newDoc.Contains("_t"))
@@ -371,7 +381,8 @@ namespace BH.Upgrader.Base
                 if (b == null)
                     return null;
 
-                Console.WriteLine("object updated: " + b.GetType().FullName);
+                if(LogToConsole)
+                    Console.WriteLine("object updated: " + b.GetType().FullName);
                 BsonDocument newDoc = new BsonDocument(b);
 
                 // Copy over BHoM properties
@@ -428,7 +439,8 @@ namespace BH.Upgrader.Base
             if (newType != null)
             {
                 document["_t"] = newType;
-                Console.WriteLine("type upgraded from " + oldType + " to " + newType);
+                if(LogToConsole)
+                    Console.WriteLine("type upgraded from " + oldType + " to " + newType);
                 return document;
             }
             else if (propertiesToRename.Count > 0)

--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -42,7 +42,7 @@ namespace BH.Upgrader.Base
         /**** Public Properties                         ****/
         /***************************************************/
 
-        public virtual bool LogToConsole { get; set; } = false;
+        public virtual bool LogToConsole { get; set; } = true;
 
         /***************************************************/
         /**** Public Methods                            ****/
@@ -50,7 +50,6 @@ namespace BH.Upgrader.Base
 
         public void ProcessingLoop(string pipeName, Converter converter)
         {
-            LogToConsole = true;
             // Make sure all assemblies are loaded
             AssemblyName[] assemblies = Assembly.GetEntryAssembly().GetReferencedAssemblies();
             foreach (AssemblyName assembly in assemblies)

--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -55,11 +55,9 @@ namespace BH.Upgrader.Base
             foreach (AssemblyName assembly in assemblies)
             {
                 Assembly.Load(assembly);
-                if(LogToConsole)
-                    Console.WriteLine("Assembly Loaded: " + assembly.Name);
+                WriteToLog("Assembly Loaded: " + assembly.Name);
             }
-            if(LogToConsole)
-                Console.WriteLine("");
+            WriteToLog("");
 
             NamedPipeClientStream pipe = null;
 
@@ -80,8 +78,8 @@ namespace BH.Upgrader.Base
                     try
                     {
                         BsonDocument doc = ReadDocument(reader);
-                        if (LogToConsole && doc != null)
-                            Console.WriteLine("document received: " + doc.ToJson());
+                        if (doc != null)
+                            WriteToLog("document received: " + doc.ToJson());
                         newDoc = Upgrade(doc, converter);
                     }
                     catch (NoUpdateException e)
@@ -115,9 +113,8 @@ namespace BH.Upgrader.Base
 
             //Clone to ensure able to compare with original document
             //Without this, the input document is changed as same reference
-            BsonDocument newDoc = new BsonDocument(document);   
-            if(LogToConsole)
-                Console.WriteLine("document received: " + document.ToJson());
+            BsonDocument newDoc = new BsonDocument(document);
+            WriteToLog("document received: " + document.ToJson());
 
             BsonDocument result = null;
             if (newDoc.Contains("_t"))
@@ -380,8 +377,7 @@ namespace BH.Upgrader.Base
                 if (b == null)
                     return null;
 
-                if(LogToConsole)
-                    Console.WriteLine("object updated: " + b.GetType().FullName);
+                WriteToLog("object updated: " + b.GetType().FullName);
                 BsonDocument newDoc = new BsonDocument(b);
 
                 // Copy over BHoM properties
@@ -438,8 +434,7 @@ namespace BH.Upgrader.Base
             if (newType != null)
             {
                 document["_t"] = newType;
-                if(LogToConsole)
-                    Console.WriteLine("type upgraded from " + oldType + " to " + newType);
+                WriteToLog("type upgraded from " + oldType + " to " + newType);
                 return document;
             }
             else if (propertiesToRename.Count > 0)
@@ -669,6 +664,14 @@ namespace BH.Upgrader.Base
             {
                 return null;
             }
+        }
+
+        /***************************************************/
+
+        private void WriteToLog(string message)
+        { 
+            if(LogToConsole)
+                Console.WriteLine(message);
         }
 
         /***************************************************/

--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -42,7 +42,7 @@ namespace BH.Upgrader.Base
         /**** Public Properties                         ****/
         /***************************************************/
 
-        public virtual bool LogToConsole { get; set; } = true;
+        public bool LogToConsole { get; set; } = true;
 
         /***************************************************/
         /**** Public Methods                            ****/


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #260

<!-- Add short description of what has been fixed -->

Turns off the console logging by default. More critical for console apps as the versioning is now called directly, leading to an bombardment of versioning logging drastically slowing the upgrader down. When ProcessingLoop is called, the logging is turned on, as this is only done when the versioning is run as a standalone .exe with its own log, and not affecting the main log of any application.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->