### PR TITLE
Avoid copying BHoM assemblies to BHoMUpgrader folder

### DIFF
--- a/BHoMUpgrader/BHoMUpgrader.csproj
+++ b/BHoMUpgrader/BHoMUpgrader.csproj
@@ -32,21 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BHoM">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="MongoDB.Bson, Version=2.18.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Bson.2.18.0\lib\net472\MongoDB.Bson.dll</HintPath>
-    </Reference>
-    <Reference Include="Reflection_Engine">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serialiser_Engine">
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -59,11 +46,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Versioning_Engine">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\ProgramData\BHoM\Assemblies\Versioning_Engine.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NoUpdateException.cs" />

--- a/BHoMUpgrader/Converter.cs
+++ b/BHoMUpgrader/Converter.cs
@@ -20,7 +20,6 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Base;
 using MongoDB.Bson;
 using System;
 using System.Collections.Generic;

--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -20,8 +20,6 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Reflection;
-using BH.oM.Base;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;

--- a/BHoMUpgrader73/BHoMUpgrader73.csproj
+++ b/BHoMUpgrader73/BHoMUpgrader73.csproj
@@ -41,6 +41,12 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Bson, Version=2.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.18.0\lib\net472\MongoDB.Bson.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Converter.cs" />

--- a/BHoMUpgrader73/BHoMUpgrader73.csproj
+++ b/BHoMUpgrader73/BHoMUpgrader73.csproj
@@ -59,13 +59,14 @@
     <ProjectReference Include="..\PostBuild\PostBuild.csproj">
       <Project>{4ec319a6-67c9-4627-9de6-046bb5bae401}</Project>
       <Name>PostBuild</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy /Y /I /E "$(TargetDir)*.dll" C:\ProgramData\BHoM\Upgrades\BHoMUpgrader73
 xcopy /Y /I /E "$(TargetDir)BHoMUpgrader73.exe" C:\ProgramData\BHoM\Upgrades\BHoMUpgrader73
-call "$(TargetDir)PostBuild.exe" ..\..\..\ "C:\ProgramData\BHoM\Upgrades"
+call "$(SolutionDir)PostBuild\Build\PostBuild.exe" ..\..\..\ "C:\ProgramData\BHoM\Upgrades"
 rename "$(TargetDir)BHoMUpgrader73.exe" "BHoMUpgrader73.dll"
 xcopy /Y /I /E "$(TargetDir)BHoMUpgrader73.dll" C:\ProgramData\BHoM\Upgrades\BHoMUpgrader73</PostBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #265

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Theoretically it should be enough if versioning check passed, but I also added a super simple manual test: just build [this branch](https://github.com/BHoM/BHoM/tree/Test-Versioning_Toolkit-%23265-AvoidCopyingBHoMAssemblies) => rebuild BHoM and Versioning_Toolkit => check if _C:\ProgramData\BHoM\Upgrades\BHoMUpgrader73_ gets populated as expected => run script from [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FVersioning%5FToolkit%2F%23266%2DAvoidCopyingBHoMAssemblies).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->