### PR TITLE
Explicit upgrade fixed to occur before the properties get upgraded

### DIFF
--- a/BHoMUpgrader/Upgrader.cs
+++ b/BHoMUpgrader/Upgrader.cs
@@ -279,17 +279,21 @@ namespace BH.Upgrader.Base
             // Check if the object type is classified as deleted or without update
             CheckForNoUpgrade(converter, oldType, "object type");
 
-            // Upgrade porperties
-            BsonDocument withNewProperties = UpgradeObjectProperties(document, converter);
-            BsonDocument newDoc = withNewProperties ?? document;
+            BsonDocument newDoc = document;
 
             //Check if there are any full object upgraders available
+            bool upgradedExplicitly = false;
             if (converter.ToNewObject.ContainsKey(oldType))
             {
                 //If so, use them to upgrade the object
                 newDoc = UpgradeObjectExplicit(newDoc, converter, oldType) ?? newDoc;
+                upgradedExplicitly = true;
             }
-            else
+
+            // Upgrade properties
+            newDoc = UpgradeObjectProperties(newDoc, converter) ?? newDoc;
+
+            if(!upgradedExplicitly)
             {
                 //If not, try upgrading the names of the types and properties
                 newDoc = UpgradeObjectTypeAndPropertyNames(newDoc, converter, oldType) ?? newDoc;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #283

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
There is no easy way to test this PR to full extent. The easiest way is to locally run versioning tests for all versions, which I did and can confirm the numbers do not change.

However, as discussed with @IsakNaslundBh it is worth digging deeper to see if the versioned objects come out the same before & after the change. I did this by modifying the versioning code locally to dump all explicitly versioned objects into a log, results uploaded [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FVersioning%5FToolkit%2F%23284%2DExplicitUpgradeFix) together with explanation of differences between `develop` and this branch.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->