### PR TITLE
Uptick to version 9.2

### DIFF
--- a/BHoMUpgrades/BHoMUpgrades.csproj
+++ b/BHoMUpgrades/BHoMUpgrades.csproj
@@ -6,7 +6,7 @@
     <Version>5.0.0</Version>
     <Copyright>Copyright © https://github.com/BHoM</Copyright>
     <RootNamespace>BH.oM.Base</RootNamespace>
-    <FileVersion>9.1.0.0</FileVersion>
+    <FileVersion>9.2.0.0</FileVersion>
     <BaseOutputPath>..\Build</BaseOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -108,10 +108,13 @@
     <None Update="Upgrades\v90.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Upgrades\v91.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Upgrades\BHoMUpgrades\&quot; /Y&#xD;&#xA;xcopy /Y /I /S /E &quot;$(TargetDir)Upgrades&quot; &quot;C:\ProgramData\BHoM\Upgrades\BHoMUpgrades\Upgrades&quot;&#xD;&#xA;call &quot;$(SolutionDir)PostBuild\Build\PostBuild.exe&quot; ..\..\ &quot;C:\ProgramData\BHoM\Upgrades\BHoMUpgrades\Upgrades\v91.json&quot;&#xD;&#xA;" />
+    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Upgrades\BHoMUpgrades\&quot; /Y&#xD;&#xA;xcopy /Y /I /S /E &quot;$(TargetDir)Upgrades&quot; &quot;C:\ProgramData\BHoM\Upgrades\BHoMUpgrades\Upgrades&quot;&#xD;&#xA;call &quot;$(SolutionDir)PostBuild\Build\PostBuild.exe&quot; ..\..\ &quot;C:\ProgramData\BHoM\Upgrades\BHoMUpgrades\Upgrades\v92.json&quot;&#xD;&#xA;" />
   </Target>
 
 </Project>

--- a/BHoMUpgrades/CustomUpgrades/v92.cs
+++ b/BHoMUpgrades/CustomUpgrades/v92.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2026, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/BHoMUpgrades/CustomUpgrades/v92.cs
+++ b/BHoMUpgrades/CustomUpgrades/v92.cs
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Versioning;
+using System.Collections.Generic;
+using System;
+
+namespace BH.Upgraders
+{
+    [Upgrader(9, 2)]
+    public static class v92
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        /***************************************************/
+    }
+}

--- a/BHoMUpgrades/Upgrades/v91.json
+++ b/BHoMUpgrades/Upgrades/v91.json
@@ -1,0 +1,295 @@
+{
+  "Namespace": {
+    "ToNew": {
+      "BH.Engine.Structures.Elements": "BH.Engine.Structure.Elements"
+    },
+    "ToOld": {
+      "BH.Engine.Structure.Elements": "BH.Engine.Structures.Elements"
+    }
+  },
+  "Type": {
+    "ToNew": {
+      "BH.oM.ElementRelationships.RelationshipType": "BH.Revit.oM.ElementRelationships.RelationshipType"
+    },
+    "ToOld": {
+      "BH.Revit.oM.ElementRelationships.RelationshipType": "BH.oM.ElementRelationships.RelationshipType"
+    }
+  },
+  "Method": {
+    "ToNew": {
+      "BH.Engine.Ground.Compute.ProduceString(BH.oM.Ground.ContaminantSample, System.Enum, System.Enum, System.Enum, System.Enum, System.Enum)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Ground.Compute, StructuralEngineering_Engine, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "FormatResult",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Ground.ContaminantSample\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Enum, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Enum, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Enum, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Enum, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Enum, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.Tagging.Query.PlacedTags(System.Collections.Generic.List<Autodesk.Revit.DB.Element>, BH.oM.Tagging.TagViewInfo, System.Collections.Generic.Dictionary<Autodesk.Revit.DB.ElementId, BH.Revit.oM.Tagging.RevitExistingTag>)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.Tagging.Query, Revit_Tagging_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "PlacedTags",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Element, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Tagging.TagViewInfo\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.Dictionary`2, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.ElementId, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }, { \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.Tagging.RevitExistingTag\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.Dictionary`2, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.Tagging.ItemInLinkId\", \"_bhomVersion\" : \"9.1\" }, { \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Tagging.ProvisionalTag\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.SecurityICT.Modify.RehostDoorHostedDevice(Autodesk.Revit.DB.Document, System.Collections.Generic.List<Autodesk.Revit.DB.FamilyInstance>, System.Double)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.SecurityICT.Modify, Revit_SecurityICT_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "RehostDoorHostedDevice",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Document, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.FamilyInstance, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.SecurityICT.Compute.LockAssemble(Autodesk.Revit.DB.Document, System.Collections.Generic.List<Autodesk.Revit.DB.FamilyInstance>)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.SecurityICT.Compute, Revit_SecurityICT_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "LockAssemble",
+        "Parameters": [
+          
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.Schematic.Query.IsInSpace(Autodesk.Revit.DB.Element, Autodesk.Revit.DB.Mechanical.Space)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.Schematic.Query, Revit_Schematic_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "IsInSpace",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Element, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Mechanical.Space, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Mechanical.Space, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.ModelManagement.Compute.SelectElementsFromList(Autodesk.Revit.DB.Document)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.ModelManagement.Compute, Revit_ModelManagement_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "SelectElementsFromList",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.UI.UIDocument, RevitAPIUI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.MechanicalPlumbing.Compute.UpdateSpacesToMatchRooms(Autodesk.Revit.DB.Document, BH.Revit.oM.MechanicalPlumbing.Settings.SpacePlacementSettings, System.Collections.Generic.List<BH.Revit.oM.MechanicalPlumbing.Pairs.SpaceRoomPair>, System.Collections.Generic.List<Autodesk.Revit.DB.Mechanical.Space>)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.MechanicalPlumbing.Compute, Revit_MechanicalPlumbing_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "UpdateSpacesToMatchRooms",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Document, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.MechanicalPlumbing.Settings.SpacePlacementSettings\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.MechanicalPlumbing.Pairs.SpaceRoomPair\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Mechanical.Space, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.MechanicalPlumbing.Pairs.SpaceRoomPair\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.Lighting.Convert.LuminaireFromText(System.String, System.Boolean)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.Lighting.Convert, Revit_Lighting_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "LuminaireFromText",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.Lighting.Compute.LightingFixtureFromText(Autodesk.Revit.DB.Document, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.Lighting.Compute, Revit_Lighting_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "LightingFixtureFromText",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Document, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.ElementRelationships.Query.Settings(BH.Adapter.ElementRelationships.ElementRelationshipAdapter)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.ElementRelationships.Query, Revit_ElementRelationships_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "Settings",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.ElementRelationships.ElementRelationshipAdapter, ElementRelationships_Adapter, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.ElementRelationships.Modify.AddElementsToRelationships(BH.oM.ElementRelationships.RelationshipSettings, BH.oM.ElementRelationships.RelationshipCollection, System.Collections.Generic.Dictionary<System.Collections.Generic.List<BH.Revit.oM.ElementRelationships.ElementItem>, System.Collections.Generic.List<BH.Revit.oM.ElementRelationships.ElementItem>>, System.Boolean)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.ElementRelationships.Modify, Revit_ElementRelationships_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "AddElementsToRelationships",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.ElementRelationships.RelationshipSettings\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.ElementRelationships.RelationshipCollection\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"System.ValueTuple`2, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.ElementRelationships.ElementItem\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }, { \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.ElementRelationships.ElementItem\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.ElementRelationships.Modify.AddElementsToRelationships(BH.oM.ElementRelationships.RelationshipSettings, BH.oM.ElementRelationships.RelationshipCollection, System.Collections.Generic.Dictionary<BH.Revit.oM.ElementRelationships.ElementItem, BH.Revit.oM.ElementRelationships.ElementItem>)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.ElementRelationships.Modify, Revit_ElementRelationships_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "AddElementsToRelationships",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.ElementRelationships.RelationshipSettings\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.ElementRelationships.RelationshipCollection\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"System.ValueTuple`2, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.ElementRelationships.ElementItem\", \"_bhomVersion\" : \"9.1\" }, { \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.ElementRelationships.ElementItem\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.ElementRelationships.Compute.ShowCollectionSelectionWindow(BH.oM.ElementRelationships.RelationshipSettings)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.ElementRelationships.Compute, Revit_ElementRelationships_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "ShowCollectionSelectionWindow",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.ElementRelationships.RelationshipSettings\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Adapter.ElementRelationships.ElementRelationshipAdapter, ElementRelationships_Adapter, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Guid, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.ElementRelationships.Compute.PlaceElements(System.Collections.Generic.List<BH.Revit.oM.ElementRelationships.ElementPlacementSettings>, System.Boolean, System.Boolean, System.Double, System.Boolean)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.ElementRelationships.Compute, Revit_ElementRelationships_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "PlaceElements",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.ElementRelationships.PlacementSettings\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.ElementRelationships.Compute.LinkClosestElements(System.Collections.Generic.List<BH.Revit.oM.ElementRelationships.ElementItem>, System.Collections.Generic.List<BH.Revit.oM.ElementRelationships.ElementItem>, System.Double, BH.oM.ElementRelationships.RelationshipType)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.ElementRelationships.Compute, Revit_ElementRelationships_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "LinkClosestElements",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.ElementRelationships.ElementItem\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.ElementRelationships.ElementItem\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.oM.ElementRelationships.RelationshipType\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.Documentation.Compute.CreateUserViews(System.String, System.Collections.Generic.List<Autodesk.Revit.DB.View>, System.Collections.Generic.List<Autodesk.Revit.DB.View>, System.Collections.Generic.List<Autodesk.Revit.DB.View>, System.String, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.Documentation.Compute, Revit_Documentation_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "CreateUserViews",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.View, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.View, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.View, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.Documentation.Compute.CreateUserTemplates(System.String, Autodesk.Revit.DB.View, Autodesk.Revit.DB.View, Autodesk.Revit.DB.View, System.String, System.String)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.Documentation.Compute, Revit_Documentation_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "CreateUserTemplates",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.View, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.View, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.View, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.Core.Query.FramingMaterial(Autodesk.Revit.DB.FamilyInstance, BH.oM.Adapters.Revit.Settings.RevitSettings, System.Collections.Generic.Dictionary<System.String, System.Collections.Generic.List<BH.oM.Base.IBHoMObject>>)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.Core.Query, Revit_Core_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "StructuralMaterial",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.FamilyInstance, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Adapters.Revit.Settings.RevitSettings\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.Dictionary`2, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }, { \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Base.IBHoMObject\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      },
+      "BH.Revit.Engine.Core.Query.Space(Autodesk.Revit.DB.Element, System.Collections.Generic.IEnumerable<Autodesk.Revit.DB.Mechanical.Space>, System.Boolean)": {
+        "_t": "System.Reflection.MethodBase",
+        "TypeName": "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Revit.Engine.Core.Query, Revit_Core_Engine_2022, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+        "MethodName": "Space",
+        "Parameters": [
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Element, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.IEnumerable`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"Autodesk.Revit.DB.Mechanical.Space, RevitAPI, Version=9.0.0.0, Culture=neutral, PublicKeyToken=null\", \"_bhomVersion\" : \"9.1\" }], \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }",
+          "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"_bhomVersion\" : \"9.1\" }"
+        ],
+        "_bhomVersion": "9.1"
+      }
+    },
+    "ToOld": {
+      
+    }
+  },
+  "Property": {
+    "ToNew": {
+      
+    },
+    "ToOld": {
+      
+    }
+  },
+  "Dataset": {
+    "ToNew": {
+      
+    },
+    "ToOld": {
+      
+    },
+    "MessageForDeleted": {
+      
+    }
+  },
+  "MessageForDeleted": {
+    "BH.Engine.UI.Compute.IOrganise(System.Collections.Generic.List<System.Object>)": "This method was used specifically to organise the UI menus. Since our UI menus are not relying on pre-loaded assemblies anymore, this method has been removed. If you need ot organise menu items, you can use `BH.Engine.UI.Compute.Organise(IEnumerable<SearchItem> items)` instead.",
+    "BH.Engine.UI.Compute.OrganiseMethods(System.Collections.Generic.List<System.Object>)": "This method was used specifically to organise the UI menus. Since our UI menus are not relying on pre-loaded assemblies anymore, this method has been removed. If you need ot organise menu items, you can use `BH.Engine.UI.Compute.Organise(IEnumerable<SearchItem> items)` instead.",
+    "BH.Engine.UI.Compute.OrganiseMembers(System.Collections.Generic.List<System.Object>)": "This method was used specifically to organise the UI menus. Since our UI menus are not relying on pre-loaded assemblies anymore, this method has been removed. If you need ot organise menu items, you can use `BH.Engine.UI.Compute.Organise(IEnumerable<SearchItem> items)` instead.",
+    "BH.Engine.UI.Compute.OrganiseTypes(System.Collections.Generic.List<System.Object>)": "This method was used specifically to organise the UI menus. Since our UI menus are not relying on pre-loaded assemblies anymore, this method has been removed. If you need ot organise menu items, you can use `BH.Engine.UI.Compute.Organise(IEnumerable<SearchItem> items)` instead.",
+    "BH.Revit.Engine.ElementRelationships.Compute.TranslationBetweenElements(BH.Revit.oM.ElementRelationships.ElementItem, BH.Revit.oM.ElementRelationships.ElementItem)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.oM.ElementRelationships.SpaceMapping.MappingPairs": "This property has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.ElementRelationships.Compute.CheckValueMapping(BH.Revit.oM.ElementRelationships.ElementItem, BH.Revit.oM.ElementRelationships.ElementItem, BH.oM.ElementRelationships.ValueMapping)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.ElementRelationships.Compute.CheckLocationMapping(BH.Revit.oM.ElementRelationships.ElementItem, BH.Revit.oM.ElementRelationships.ElementItem, BH.oM.ElementRelationships.LocationMapping, BH.oM.Geometry.TransformMatrix)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.ElementRelationships.Compute.CheckSpaceMapping(System.Collections.Generic.List<BH.oM.Base.IObject>, System.Collections.Generic.List<BH.oM.Base.IObject>, BH.oM.ElementRelationships.SpaceMapping)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.ElementRelationships.Compute.CheckAggregateMapping(System.Collections.Generic.List<BH.oM.Base.IObject>, System.Collections.Generic.List<BH.oM.Base.IObject>, BH.oM.ElementRelationships.IAggregateMapping)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.ElementRelationships.Compute.ExecuteValueMapping(BH.Revit.oM.ElementRelationships.ElementItem, BH.Revit.oM.ElementRelationships.ElementItem, BH.oM.ElementRelationships.ValueMapping)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.ElementRelationships.Compute.ExecuteLocationMapping(BH.Revit.oM.ElementRelationships.ElementItem, BH.Revit.oM.ElementRelationships.ElementItem, BH.oM.ElementRelationships.LocationMapping, BH.oM.Geometry.TransformMatrix)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.ElementRelationships.Compute.ExecuteAggregateMapping(System.Collections.Generic.List<BH.oM.Base.IObject>, System.Collections.Generic.List<BH.oM.Base.IObject>, BH.oM.ElementRelationships.IAggregateMapping)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.ModelManagement.Query.Solids(Autodesk.Revit.DB.Element)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.SecurityICT.Query.CuboidFace(Autodesk.Revit.DB.Element, BH.Revit.oM.SecurityICT.CuboidFace)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.SecurityICT.Query.Solid(Autodesk.Revit.DB.Element, Autodesk.Revit.DB.ViewDetailLevel)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.SecurityICT.Query.RectangularFaceVertex(Autodesk.Revit.DB.PlanarFace, BH.Revit.oM.SecurityICT.FaceVertices)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.Engine.SecurityICT.Compute.AddLockAssemblyItems(Autodesk.Revit.DB.FamilyInstance, BH.Revit.oM.SecurityICT.LockConfiguration, System.Collections.Generic.List<System.String>, System.Collections.Generic.Dictionary<BH.Revit.oM.SecurityICT.LockItem, Autodesk.Revit.DB.FamilySymbol>)": "This method has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.oM.SecurityICT.Enums.CuboidFace": "This object has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.oM.SecurityICT.Enums.DoorSide": "This object has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.oM.SecurityICT.Enums.FaceVertices": "This object has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.oM.SecurityICT.Enums.LateralPosition": "This object has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.oM.SecurityICT.Logging.LockAssembleLogItem": "This object has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.oM.SecurityICT.LockConfiguration": "This object has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.oM.SecurityICT.LockItem": "This object has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it.",
+    "BH.Revit.oM.SecurityICT.SecuritySettings": "This object has been removed as a part of the legacy code cleanup. Please contact the developers if you still need it."
+  },
+  "MessageForNoUpgrade": {
+    
+  }
+}

--- a/PostBuild/PostBuild.csproj
+++ b/PostBuild/PostBuild.csproj
@@ -9,7 +9,7 @@
     <Product>PostBuild</Product>
     <Copyright>Copyright © https://github.com/BHoM</Copyright>
     <AssemblyVersion>9.0.0.0</AssemblyVersion>
-    <FileVersion>9.1.0.0</FileVersion>
+    <FileVersion>9.2.0.0</FileVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">


### PR DESCRIPTION
### NOTE: Depends on 

### Issues addressed by this PR

Closes #

Version uptick from 9.1 to 9.2 as part of the end-of-milestone procedure: https://github.com/BHoM/Versioning_Toolkit/wiki/End-of-milestone-procedure

- Added `v91.json` to `BHoMUpgrades/Upgrades/` and registered it in the csproj with `CopyToOutputDirectory=Always` (freezing the 9.1 milestone)
- Added `v92.cs` to `BHoMUpgrades/CustomUpgrades/` for the new milestone
- Updated PostBuild target to generate `v92.json`
- Updated `FileVersion` to `9.2.0.0` in `BHoMUpgrades` and `PostBuild`

### Test files

### Changelog

### Additional comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk versioning housekeeping: adds a new milestone upgrader scaffold and updates build metadata/output paths, with no functional runtime logic changes beyond upgrade mapping data.
> 
> **Overview**
> Updates the versioning toolkit for the `9.2` milestone by bumping `FileVersion` to `9.2.0.0` in `BHoMUpgrades` and `PostBuild`.
> 
> Freezes the `9.1` milestone by adding and shipping `Upgrades/v91.json` (namespace/type/method remaps plus deleted-member messages) and registering it for output copying.
> 
> Prepares the next milestone by adding an empty `CustomUpgrades/v92.cs` upgrader stub and updating the `BHoMUpgrades` post-build step to generate `v92.json` instead of `v91.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15cc7b5a753eab86aea033d2e1acf90e98f4cdb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->