### PR TITLE
Version tagging settings

### DIFF
--- a/BHoMUpgrades/CustomUpgrades/v93.cs
+++ b/BHoMUpgrades/CustomUpgrades/v93.cs
@@ -58,10 +58,92 @@ namespace BH.Upgraders
 
         /***************************************************/
 
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.RevitPointTagSettings")]
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.RevitCurveTagSettings")]
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.RevitAreaTagSettings")]
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.MEPPointTagSettings")]
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.MEPCurveTagSettings")]
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.MEPAreaTagSettings")]
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.StructurePointTagSettings")]
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.StructureCurveTagSettings")]
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.StructureAreaTagSettings")]
+        public static Dictionary<string, object> UpgradeRevitTagSettingsTagObscured(Dictionary<string, object> oldVersion)
+        {
+            //TagObscuredDisciplineElements moved from the nested BhomSettings (BH.oM.Tagging.Settings.BaseTagSettings)
+            //up to this Revit-side settings object (BH.Revit.oM.Tagging.Settings.BaseRevitTagSettings), since it is
+            //only ever consumed by Revit-specific tagging logic.
+            return HoistFromBhomSettings(oldVersion, "TagObscuredDisciplineElements");
+        }
+
+        /***************************************************/
+
         [VersioningTarget("BH.oM.Tagging.Settings.PointTagSettings")]
+        public static Dictionary<string, object> UpgradePointTagSettings(Dictionary<string, object> oldVersion)
+        {
+            return FlattenBaseSettings(oldVersion);
+        }
+
+        /***************************************************/
+
         [VersioningTarget("BH.oM.Tagging.Settings.CurveTagSettings")]
+        public static Dictionary<string, object> UpgradeCurveTagSettings(Dictionary<string, object> oldVersion)
+        {
+            Dictionary<string, object> newVersion = FlattenBaseSettings(oldVersion);
+            if (newVersion == null)
+                return null;
+
+            //KeepTagPlacementPointOnHost moved from BaseTagSettings to PointTagSettings and AreaTagSettings only.
+            //It was never used by CurveTagSettings, so it is dropped rather than carried over.
+            newVersion.Remove("KeepTagPlacementPointOnHost");
+
+            return newVersion;
+        }
+
+        /***************************************************/
+
         [VersioningTarget("BH.oM.Tagging.Settings.AreaTagSettings")]
-        public static Dictionary<string, object> UpgradeBaseTagSettings(Dictionary<string, object> oldVersion)
+        public static Dictionary<string, object> UpgradeAreaTagSettings(Dictionary<string, object> oldVersion)
+        {
+            Dictionary<string, object> newVersion = FlattenBaseSettings(oldVersion);
+            if (newVersion == null)
+                return null;
+
+            //RiserLeaderAngle moved from BaseTagSettings to PointTagSettings and CurveTagSettings only.
+            //It was never used by AreaTagSettings, so it is dropped rather than carried over.
+            newVersion.Remove("RiserLeaderAngle");
+
+            return newVersion;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static Dictionary<string, object> HoistFromBhomSettings(Dictionary<string, object> oldVersion, string propertyName)
+        {
+            if (oldVersion == null)
+                return null;
+
+            Dictionary<string, object> newVersion = new Dictionary<string, object>(oldVersion);
+
+            object bhomSettingsObject;
+            if (newVersion.TryGetValue("BhomSettings", out bhomSettingsObject))
+            {
+                Dictionary<string, object> bhomSettings = bhomSettingsObject as Dictionary<string, object>;
+                object propertyValue;
+                if (bhomSettings != null && bhomSettings.TryGetValue(propertyName, out propertyValue))
+                {
+                    newVersion[propertyName] = propertyValue;
+                    bhomSettings.Remove(propertyName);
+                }
+            }
+
+            return newVersion;
+        }
+
+        /***************************************************/
+
+        private static Dictionary<string, object> FlattenBaseSettings(Dictionary<string, object> oldVersion)
         {
             if (oldVersion == null)
                 return null;

--- a/BHoMUpgrades/CustomUpgrades/v93.cs
+++ b/BHoMUpgrades/CustomUpgrades/v93.cs
@@ -57,5 +57,38 @@ namespace BH.Upgraders
         }
 
         /***************************************************/
+
+        [VersioningTarget("BH.oM.Tagging.Settings.PointTagSettings")]
+        [VersioningTarget("BH.oM.Tagging.Settings.CurveTagSettings")]
+        [VersioningTarget("BH.oM.Tagging.Settings.AreaTagSettings")]
+        public static Dictionary<string, object> UpgradeBaseTagSettings(Dictionary<string, object> oldVersion)
+        {
+            if (oldVersion == null)
+                return null;
+
+            Dictionary<string, object> newVersion = new Dictionary<string, object>(oldVersion);
+
+            object baseSettingsObject;
+            if (newVersion.TryGetValue("BaseSettings", out baseSettingsObject))
+            {
+                Dictionary<string, object> baseSettings = baseSettingsObject as Dictionary<string, object>;
+                if (baseSettings != null)
+                {
+                    foreach (KeyValuePair<string, object> kvp in baseSettings)
+                    {
+                        if (kvp.Key == "_t")
+                            continue;
+
+                        newVersion[kvp.Key] = kvp.Value;
+                    }
+                }
+
+                newVersion.Remove("BaseSettings");
+            }
+
+            return newVersion;
+        }
+
+        /***************************************************/
     }
 }

--- a/BHoMUpgrades/CustomUpgrades/v93.cs
+++ b/BHoMUpgrades/CustomUpgrades/v93.cs
@@ -58,29 +58,22 @@ namespace BH.Upgraders
 
         /***************************************************/
 
-        [VersioningTarget("BH.Revit.oM.Tagging.Settings.RevitPointTagSettings")]
-        [VersioningTarget("BH.Revit.oM.Tagging.Settings.RevitCurveTagSettings")]
-        [VersioningTarget("BH.Revit.oM.Tagging.Settings.RevitAreaTagSettings")]
-        [VersioningTarget("BH.Revit.oM.Tagging.Settings.MEPPointTagSettings")]
-        [VersioningTarget("BH.Revit.oM.Tagging.Settings.MEPCurveTagSettings")]
-        [VersioningTarget("BH.Revit.oM.Tagging.Settings.MEPAreaTagSettings")]
-        [VersioningTarget("BH.Revit.oM.Tagging.Settings.StructurePointTagSettings")]
-        [VersioningTarget("BH.Revit.oM.Tagging.Settings.StructureCurveTagSettings")]
-        [VersioningTarget("BH.Revit.oM.Tagging.Settings.StructureAreaTagSettings")]
-        public static Dictionary<string, object> UpgradeRevitTagSettingsTagObscured(Dictionary<string, object> oldVersion)
-        {
-            //TagObscuredDisciplineElements moved from the nested BhomSettings (BH.oM.Tagging.Settings.BaseTagSettings)
-            //up to this Revit-side settings object (BH.Revit.oM.Tagging.Settings.BaseRevitTagSettings), since it is
-            //only ever consumed by Revit-specific tagging logic.
-            return HoistFromBhomSettings(oldVersion, "TagObscuredDisciplineElements");
-        }
-
-        /***************************************************/
-
         [VersioningTarget("BH.oM.Tagging.Settings.PointTagSettings")]
         public static Dictionary<string, object> UpgradePointTagSettings(Dictionary<string, object> oldVersion)
         {
-            return FlattenBaseSettings(oldVersion);
+            Dictionary<string, object> newVersion = FlattenBaseSettings(oldVersion);
+            if (newVersion == null)
+                return null;
+
+            //TagObscuredDisciplineElements moved out of BaseTagSettings entirely, onto the Revit-side
+            //BaseRevitTagSettings (BH.Revit.oM.Tagging.Settings), which is not reachable from this custom
+            //upgrader (it only ever runs for the nested BhomSettings object, never the outer Revit wrapper -
+            //the property does not exist at that outer level in old data, so its own upgrade never triggers).
+            //There is no way to carry the old value across that boundary through this API, so it is dropped;
+            //it resets to the default on import of pre-9.3 settings, same as GlobalTagSettings.UseExclusionZones.
+            newVersion.Remove("TagObscuredDisciplineElements");
+
+            return newVersion;
         }
 
         /***************************************************/
@@ -95,6 +88,9 @@ namespace BH.Upgraders
             //KeepTagPlacementPointOnHost moved from BaseTagSettings to PointTagSettings and AreaTagSettings only.
             //It was never used by CurveTagSettings, so it is dropped rather than carried over.
             newVersion.Remove("KeepTagPlacementPointOnHost");
+
+            //See UpgradePointTagSettings for why TagObscuredDisciplineElements is dropped here too.
+            newVersion.Remove("TagObscuredDisciplineElements");
 
             return newVersion;
         }
@@ -112,35 +108,14 @@ namespace BH.Upgraders
             //It was never used by AreaTagSettings, so it is dropped rather than carried over.
             newVersion.Remove("RiserLeaderAngle");
 
+            //See UpgradePointTagSettings for why TagObscuredDisciplineElements is dropped here too.
+            newVersion.Remove("TagObscuredDisciplineElements");
+
             return newVersion;
         }
 
         /***************************************************/
         /**** Private Methods                           ****/
-        /***************************************************/
-
-        private static Dictionary<string, object> HoistFromBhomSettings(Dictionary<string, object> oldVersion, string propertyName)
-        {
-            if (oldVersion == null)
-                return null;
-
-            Dictionary<string, object> newVersion = new Dictionary<string, object>(oldVersion);
-
-            object bhomSettingsObject;
-            if (newVersion.TryGetValue("BhomSettings", out bhomSettingsObject))
-            {
-                Dictionary<string, object> bhomSettings = bhomSettingsObject as Dictionary<string, object>;
-                object propertyValue;
-                if (bhomSettings != null && bhomSettings.TryGetValue(propertyName, out propertyValue))
-                {
-                    newVersion[propertyName] = propertyValue;
-                    bhomSettings.Remove(propertyName);
-                }
-            }
-
-            return newVersion;
-        }
-
         /***************************************************/
 
         private static Dictionary<string, object> FlattenBaseSettings(Dictionary<string, object> oldVersion)

--- a/BHoMUpgrades/CustomUpgrades/v93.cs
+++ b/BHoMUpgrades/CustomUpgrades/v93.cs
@@ -33,6 +33,29 @@ namespace BH.Upgraders
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [VersioningTarget("BH.Revit.oM.Tagging.Settings.MEPGlobalTagSettings")]
+        public static Dictionary<string, object> UpgradeMEPGlobalTagSettings(Dictionary<string, object> oldVersion)
+        {
+            if (oldVersion == null)
+                return null;
+
+            Dictionary<string, object> newVersion = new Dictionary<string, object>(oldVersion);
+
+            object bhomSettingsObject;
+            if (newVersion.TryGetValue("BhomSettings", out bhomSettingsObject))
+            {
+                Dictionary<string, object> bhomSettings = bhomSettingsObject as Dictionary<string, object>;
+                object useExclusionZones;
+                if (bhomSettings != null && bhomSettings.TryGetValue("UseExclusionZones", out useExclusionZones))
+                {
+                    newVersion["UseExclusionZones"] = useExclusionZones;
+                    bhomSettings.Remove("UseExclusionZones");
+                }
+            }
+
+            return newVersion;
+        }
+
         /***************************************************/
     }
 }

--- a/BHoMUpgrades/CustomUpgrades/v93.cs
+++ b/BHoMUpgrades/CustomUpgrades/v93.cs
@@ -22,7 +22,6 @@
 
 using BH.oM.Versioning;
 using System.Collections.Generic;
-using System;
 
 namespace BH.Upgraders
 {
@@ -65,12 +64,15 @@ namespace BH.Upgraders
             if (newVersion == null)
                 return null;
 
-            //TagObscuredDisciplineElements moved out of BaseTagSettings entirely, onto the Revit-side
-            //BaseRevitTagSettings (BH.Revit.oM.Tagging.Settings), which is not reachable from this custom
-            //upgrader (it only ever runs for the nested BhomSettings object, never the outer Revit wrapper -
-            //the property does not exist at that outer level in old data, so its own upgrade never triggers).
-            //There is no way to carry the old value across that boundary through this API, so it is dropped;
-            //it resets to the default on import of pre-9.3 settings, same as GlobalTagSettings.UseExclusionZones.
+            //RiserLeaderAngle renamed to OrthogonalLeaderAngle on PointTagSettings.
+            object riserLeaderAngle;
+            if (newVersion.TryGetValue("RiserLeaderAngle", out riserLeaderAngle))
+            {
+                newVersion["OrthogonalLeaderAngle"] = riserLeaderAngle;
+                newVersion.Remove("RiserLeaderAngle");
+            }
+
+            //TagObscuredDisciplineElements moved out of BaseTagSettings entirely, onto the Revit-side BaseRevitTagSettings
             newVersion.Remove("TagObscuredDisciplineElements");
 
             return newVersion;

--- a/BHoMUpgrades/CustomUpgrades/v93.cs
+++ b/BHoMUpgrades/CustomUpgrades/v93.cs
@@ -29,7 +29,7 @@ namespace BH.Upgraders
     public static class v93
     {
         /***************************************************/
-        /**** Public Methods                            ****/
+        /****              Public Methods               ****/
         /***************************************************/
 
         [VersioningTarget("BH.Revit.oM.Tagging.Settings.MEPGlobalTagSettings")]
@@ -40,12 +40,11 @@ namespace BH.Upgraders
 
             Dictionary<string, object> newVersion = new Dictionary<string, object>(oldVersion);
 
-            object bhomSettingsObject;
-            if (newVersion.TryGetValue("BhomSettings", out bhomSettingsObject))
+            if (newVersion.TryGetValue("BhomSettings", out object bhomSettingsObject))
             {
                 Dictionary<string, object> bhomSettings = bhomSettingsObject as Dictionary<string, object>;
-                object useExclusionZones;
-                if (bhomSettings != null && bhomSettings.TryGetValue("UseExclusionZones", out useExclusionZones))
+
+                if (bhomSettings != null && bhomSettings.TryGetValue("UseExclusionZones", out object useExclusionZones))
                 {
                     newVersion["UseExclusionZones"] = useExclusionZones;
                     bhomSettings.Remove("UseExclusionZones");
@@ -65,8 +64,7 @@ namespace BH.Upgraders
                 return null;
 
             //RiserLeaderAngle renamed to OrthogonalLeaderAngle on PointTagSettings.
-            object riserLeaderAngle;
-            if (newVersion.TryGetValue("RiserLeaderAngle", out riserLeaderAngle))
+            if (newVersion.TryGetValue("RiserLeaderAngle", out object riserLeaderAngle))
             {
                 newVersion["OrthogonalLeaderAngle"] = riserLeaderAngle;
                 newVersion.Remove("RiserLeaderAngle");
@@ -117,7 +115,7 @@ namespace BH.Upgraders
         }
 
         /***************************************************/
-        /**** Private Methods                           ****/
+        /****             Private Methods               ****/
         /***************************************************/
 
         private static Dictionary<string, object> FlattenBaseSettings(Dictionary<string, object> oldVersion)
@@ -127,8 +125,7 @@ namespace BH.Upgraders
 
             Dictionary<string, object> newVersion = new Dictionary<string, object>(oldVersion);
 
-            object baseSettingsObject;
-            if (newVersion.TryGetValue("BaseSettings", out baseSettingsObject))
+            if (newVersion.TryGetValue("BaseSettings", out object baseSettingsObject))
             {
                 Dictionary<string, object> baseSettings = baseSettingsObject as Dictionary<string, object>;
                 if (baseSettings != null)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Helps close https://github.com/BuroHappoldEngineering/Revit_Tagging_Tool/issues/179

<!-- Add short description of what has been fixed -->
This pull request introduces several upgrade methods to the `v93` upgrader, focusing on improving the migration of tagging settings objects to newer versions. The main enhancements involve flattening nested settings structures and handling property renames or removals to align with updated object models.

**New upgrade methods for tagging settings:**

* Added `UpgradeMEPGlobalTagSettings` to flatten the `UseExclusionZones` property from the nested `BhomSettings` dictionary to the top level and remove it from the nested dictionary. ([[BHoMUpgrades/CustomUpgrades/v93.csR35-R150](diffhunk://#diff-ddada7c80334fcc484ac0ca7fd2ae2959d8c70dc7f98cf43ad6539c8d1b54440R35-R150)])
* Added `UpgradePointTagSettings` to flatten base settings, rename `RiserLeaderAngle` to `OrthogonalLeaderAngle`, and remove `TagObscuredDisciplineElements`. ([[BHoMUpgrades/CustomUpgrades/v93.csR35-R150](diffhunk://#diff-ddada7c80334fcc484ac0ca7fd2ae2959d8c70dc7f98cf43ad6539c8d1b54440R35-R150)])
* Added `UpgradeCurveTagSettings` to flatten base settings and remove both `KeepTagPlacementPointOnHost` and `TagObscuredDisciplineElements`. ([[BHoMUpgrades/CustomUpgrades/v93.csR35-R150](diffhunk://#diff-ddada7c80334fcc484ac0ca7fd2ae2959d8c70dc7f98cf43ad6539c8d1b54440R35-R150)])
* Added `UpgradeAreaTagSettings` to flatten base settings and remove both `RiserLeaderAngle` and `TagObscuredDisciplineElements`. ([[BHoMUpgrades/CustomUpgrades/v93.csR35-R150](diffhunk://#diff-ddada7c80334fcc484ac0ca7fd2ae2959d8c70dc7f98cf43ad6539c8d1b54440R35-R150)])

**Helper method for flattening:**

* Introduced a private `FlattenBaseSettings` method to move properties from the nested `BaseSettings` dictionary to the top level, simplifying the upgrade logic for all tagging settings. ([[BHoMUpgrades/CustomUpgrades/v93.csR35-R150](diffhunk://#diff-ddada7c80334fcc484ac0ca7fd2ae2959d8c70dc7f98cf43ad6539c8d1b54440R35-R150)])

### Test files
<!-- Link to test files to validate the proposed changes -->
Please see https://github.com/BuroHappoldEngineering/Revit_Tagging_Tool/pull/180

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->